### PR TITLE
Custom buttons

### DIFF
--- a/SparkleSpin.xcodeproj/project.pbxproj
+++ b/SparkleSpin.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0601DDDE222EF45D00CFBDE3 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0601DDDD222EF45D00CFBDE3 /* HomeViewController.swift */; };
+		0601DDE2222EFA7F00CFBDE3 /* LightButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0601DDE1222EFA7F00CFBDE3 /* LightButton.swift */; };
 		060C4D11221F425600B0BB07 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 060C4D10221F425600B0BB07 /* Images.xcassets */; };
 		060C4D13222047AC00B0BB07 /* JUICE_Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 060C4D12222047AC00B0BB07 /* JUICE_Regular.ttf */; };
 		060C4D15222047BA00B0BB07 /* Library 3 am.otf in Resources */ = {isa = PBXBuildFile; fileRef = 060C4D14222047BA00B0BB07 /* Library 3 am.otf */; };
@@ -41,6 +42,7 @@
 
 /* Begin PBXFileReference section */
 		0601DDDD222EF45D00CFBDE3 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
+		0601DDE1222EFA7F00CFBDE3 /* LightButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightButton.swift; sourceTree = "<group>"; };
 		060C4D10221F425600B0BB07 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		060C4D12222047AC00B0BB07 /* JUICE_Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = JUICE_Regular.ttf; sourceTree = "<group>"; };
 		060C4D14222047BA00B0BB07 /* Library 3 am.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Library 3 am.otf"; sourceTree = "<group>"; };
@@ -92,6 +94,14 @@
 			path = Controllers;
 			sourceTree = "<group>";
 		};
+		0601DDE0222EFA1400CFBDE3 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				0601DDE1222EFA7F00CFBDE3 /* LightButton.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
 		060C4D1A2227107C00B0BB07 /* Models */ = {
 			isa = PBXGroup;
 			children = (
@@ -131,6 +141,7 @@
 		064A0199221B3BED001AE3AF /* SparkleSpin */ = {
 			isa = PBXGroup;
 			children = (
+				0601DDE0222EFA1400CFBDE3 /* Views */,
 				0601DDDC222EF2BE00CFBDE3 /* Controllers */,
 				060C4D1D22271E3E00B0BB07 /* ViewModels */,
 				060C4D1A2227107C00B0BB07 /* Models */,
@@ -294,6 +305,7 @@
 				060C4D1C222710C100B0BB07 /* PlayerModel.swift in Sources */,
 				060C4D21222754D400B0BB07 /* ChoreModel.swift in Sources */,
 				060C4D1F22271E6800B0BB07 /* PlayerViewModel.swift in Sources */,
+				0601DDE2222EFA7F00CFBDE3 /* LightButton.swift in Sources */,
 				064A01CE221C77A3001AE3AF /* Image.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SparkleSpin/Base.lproj/Main.storyboard
+++ b/SparkleSpin/Base.lproj/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina4_7" orientation="portrait">
+    <device id="retina5_9" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -10,27 +10,47 @@
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
+    <customFonts key="customFonts">
+        <array key="saxmono.ttf">
+            <string>saxMono</string>
+        </array>
+    </customFonts>
     <scenes>
         <!--Home View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="HomeViewController" customModule="SparkleSpin" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="logo-composite-dark" translatesAutoresizingMaskIntoConstraints="NO" id="adv-ti-P4X">
-                                <rect key="frame" x="28" y="233" width="319" height="201"/>
+                                <rect key="frame" x="28" y="305.66666666666669" width="319" height="201"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="319" id="ECq-Jb-cPA"/>
                                     <constraint firstAttribute="height" constant="201" id="qhM-se-ybu"/>
                                 </constraints>
                             </imageView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="fFr-J3-6al" customClass="LightButton" customModule="SparkleSpin" customModuleProvider="target">
+                                <rect key="frame" x="28" y="630" width="319" height="58"/>
+                                <color key="backgroundColor" name="LightColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="58" id="hXg-oA-lSx"/>
+                                    <constraint firstAttribute="width" constant="319" id="m2u-hF-gNR"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" name="saxMono" family="saxMono" pointSize="32"/>
+                                <state key="normal" title="Start!">
+                                    <color key="titleColor" name="DarkColor"/>
+                                </state>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" name="LightColor"/>
                         <constraints>
+                            <constraint firstItem="fFr-J3-6al" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="28" id="6rt-Qm-iqI"/>
                             <constraint firstItem="adv-ti-P4X" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="BnJ-mJ-PeF"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="fFr-J3-6al" secondAttribute="bottom" constant="90" id="WZj-ew-2LE"/>
                             <constraint firstItem="adv-ti-P4X" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="kIE-5L-Egy"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="fFr-J3-6al" secondAttribute="trailing" constant="28" id="lyo-Lh-7vV"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
@@ -41,6 +61,9 @@
     </scenes>
     <resources>
         <image name="logo-composite-dark" width="319" height="201"/>
+        <namedColor name="DarkColor">
+            <color red="0.10980392156862745" green="0.11764705882352941" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+        </namedColor>
         <namedColor name="LightColor">
             <color red="0.96470588235294119" green="0.96470588235294119" blue="0.96470588235294119" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
         </namedColor>

--- a/SparkleSpin/Base.lproj/Main.storyboard
+++ b/SparkleSpin/Base.lproj/Main.storyboard
@@ -11,8 +11,8 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
-        <array key="saxmono.ttf">
-            <string>saxMono</string>
+        <array key="Library 3 am.otf">
+            <string>LIBRARY3AM</string>
         </array>
     </customFonts>
     <scenes>
@@ -38,10 +38,13 @@
                                     <constraint firstAttribute="height" constant="58" id="hXg-oA-lSx"/>
                                     <constraint firstAttribute="width" constant="319" id="m2u-hF-gNR"/>
                                 </constraints>
-                                <fontDescription key="fontDescription" name="saxMono" family="saxMono" pointSize="32"/>
+                                <fontDescription key="fontDescription" name="LIBRARY3AM" family="LIBRARY 3 AM" pointSize="32"/>
                                 <state key="normal" title="Start!">
                                     <color key="titleColor" name="DarkColor"/>
                                 </state>
+                                <connections>
+                                    <action selector="startButtonIsTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="V4m-cD-5pY"/>
+                                </connections>
                             </button>
                         </subviews>
                         <color key="backgroundColor" name="LightColor"/>

--- a/SparkleSpin/Controllers/HomeViewController.swift
+++ b/SparkleSpin/Controllers/HomeViewController.swift
@@ -12,19 +12,11 @@ class HomeViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    
+    @IBAction func startButtonIsTapped(_ sender: LightButton) {
+        sender.animateButton()
     }
-    */
 
 }

--- a/SparkleSpin/Views/LightButton.swift
+++ b/SparkleSpin/Views/LightButton.swift
@@ -22,13 +22,52 @@ class LightButton: UIButton {
         styleButton()
     }
     
+    override var isHighlighted: Bool {
+        didSet {
+            if isHighlighted {
+                isHighlighted = false
+                self.setTitleColor(ThemeColor.Light.accentColorTwo, for: .normal)
+            } else {
+                self.setTitleColor(ThemeColor.Light.secondaryColor, for: .normal)
+            }
+            
+        }
+    }
+    
+    
     private func styleButton() {
-        self.backgroundColor = ThemeColor.Light.primaryColor
-        self.layer.cornerRadius = 8
-        self.layer.shadowColor = ThemeColor.Light.secondaryColor?.cgColor
-        self.layer.shadowOffset = CGSize(width: 1.5, height: 2.0)
-        self.layer.shadowOpacity = 0.9
-        self.layer.shadowRadius = 2.0
-        self.layer.masksToBounds = false
+        
+        backgroundColor = ThemeColor.Light.primaryColor
+        layer.cornerRadius = 8
+        layer.shadowColor = ThemeColor.Light.secondaryColor?.cgColor
+        layer.shadowOffset = CGSize(width: 1.5, height: 2.0)
+        layer.shadowOpacity = 0.9
+        layer.shadowRadius = 2.0
+        layer.masksToBounds = false
+        
+        
+    }
+    
+    func animateButton() {
+
+        let animation = CABasicAnimation(keyPath: "shadowRadius")
+        animation.fromValue = 2.0
+        animation.toValue = 0.5
+        animation.duration = 0.15
+        
+        
+        let shadowAnimation = CABasicAnimation(keyPath: "shadowOffSet")
+        shadowAnimation.fromValue = CGSize(width: 1.5, height: 2.0)
+        shadowAnimation.toValue = CGSize(width: 0.0, height: 0.0)
+        shadowAnimation.duration = 0.15
+        
+        let opacityAnimation = CABasicAnimation(keyPath: "shadowOpacity")
+        opacityAnimation.fromValue = 0.9
+        opacityAnimation.toValue = 0.0
+        opacityAnimation.duration = 0.15
+        
+        layer.add(opacityAnimation, forKey: "shadowOpacity")
+        layer.add(animation, forKey: "shadowRadius")
+        layer.add(shadowAnimation, forKey: "shadowOffSet")
     }
 }

--- a/SparkleSpin/Views/LightButton.swift
+++ b/SparkleSpin/Views/LightButton.swift
@@ -1,0 +1,34 @@
+//
+//  LightButton.swift
+//  SparkleSpin
+//
+//  Created by Britney Smith on 3/5/19.
+//  Copyright © 2019 Britney Smith. All rights reserved.
+//
+
+import UIKit
+
+class LightButton: UIButton {
+    
+    var buttonTitle: String?
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        styleButton()
+        buttonTitle = "Example"
+    }
+    
+    private func styleButton() {
+        self.backgroundColor = ThemeColor.Light.primaryColor
+        self.layer.cornerRadius = 8
+        self.layer.shadowColor = ThemeColor.Light.secondaryColor?.cgColor
+        self.layer.shadowOffset = CGSize(width: 0.0, height: 2.0)
+        self.layer.shadowOpacity = 1.0
+        self.layer.shadowRadius = 0.0
+        self.layer.masksToBounds = false
+    }
+}

--- a/SparkleSpin/Views/LightButton.swift
+++ b/SparkleSpin/Views/LightButton.swift
@@ -8,27 +8,27 @@
 
 import UIKit
 
+@IBDesignable
 class LightButton: UIButton {
     
-    var buttonTitle: String?
-    
+
     override init(frame: CGRect) {
         super.init(frame: frame)
+        styleButton()
     }
     
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         styleButton()
-        buttonTitle = "Example"
     }
     
     private func styleButton() {
         self.backgroundColor = ThemeColor.Light.primaryColor
         self.layer.cornerRadius = 8
         self.layer.shadowColor = ThemeColor.Light.secondaryColor?.cgColor
-        self.layer.shadowOffset = CGSize(width: 0.0, height: 2.0)
-        self.layer.shadowOpacity = 1.0
-        self.layer.shadowRadius = 0.0
+        self.layer.shadowOffset = CGSize(width: 1.5, height: 2.0)
+        self.layer.shadowOpacity = 0.9
+        self.layer.shadowRadius = 2.0
         self.layer.masksToBounds = false
     }
 }

--- a/SparkleSpin/Views/LightButton.swift
+++ b/SparkleSpin/Views/LightButton.swift
@@ -55,7 +55,6 @@ class LightButton: UIButton {
         animation.toValue = 0.5
         animation.duration = 0.15
         
-        
         let shadowAnimation = CABasicAnimation(keyPath: "shadowOffSet")
         shadowAnimation.fromValue = CGSize(width: 1.5, height: 2.0)
         shadowAnimation.toValue = CGSize(width: 0.0, height: 0.0)


### PR DESCRIPTION
## What you did :question:
This PR adds the `LightButton` subclass, which adds functionality for buttons of this class to animate when tapped. The subclass also removes the default button text highlighting by overriding `UIButton.isHighlighted`.

## How to test it :microscope:
- Check out this branch
- Run the app
- On the Home screen, tap the `Start` button
- Note that the text flashes pink and the button is animated on tap (see screenshot below)

## Any background context you want to provide? :question:
The animations on the button itself are not permanent--when the segue is added, the current transition may be found to be inappropriate. These placeholder animations exist just to get started with adding `CABasicAnimation` types.


## Screenshots (if applicable) :camera:

![mar-06-2019 15-29-19](https://user-images.githubusercontent.com/8409475/53911666-19a93d00-4025-11e9-9991-a0681488d77a.gif)


