### PR TITLE
Player screen

### DIFF
--- a/SparkleSpin.xcodeproj/project.pbxproj
+++ b/SparkleSpin.xcodeproj/project.pbxproj
@@ -11,6 +11,9 @@
 		0601DDE2222EFA7F00CFBDE3 /* LightButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0601DDE1222EFA7F00CFBDE3 /* LightButton.swift */; };
 		0601DE21223DBA1500CFBDE3 /* PlayerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0601DE20223DBA1500CFBDE3 /* PlayerViewController.swift */; };
 		0601DE24223DBC4F00CFBDE3 /* Identifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0601DE23223DBC4F00CFBDE3 /* Identifier.swift */; };
+		0601DE26223EA98800CFBDE3 /* CustomTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0601DE25223EA98800CFBDE3 /* CustomTextField.swift */; };
+		0601DE2A223EAF2400CFBDE3 /* EntryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0601DE28223EAF2400CFBDE3 /* EntryCell.swift */; };
+		0601DE2B223EAF2400CFBDE3 /* EntryCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0601DE29223EAF2400CFBDE3 /* EntryCell.xib */; };
 		060C4D11221F425600B0BB07 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 060C4D10221F425600B0BB07 /* Images.xcassets */; };
 		060C4D13222047AC00B0BB07 /* JUICE_Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 060C4D12222047AC00B0BB07 /* JUICE_Regular.ttf */; };
 		060C4D15222047BA00B0BB07 /* Library 3 am.otf in Resources */ = {isa = PBXBuildFile; fileRef = 060C4D14222047BA00B0BB07 /* Library 3 am.otf */; };
@@ -47,6 +50,9 @@
 		0601DDE1222EFA7F00CFBDE3 /* LightButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightButton.swift; sourceTree = "<group>"; };
 		0601DE20223DBA1500CFBDE3 /* PlayerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerViewController.swift; sourceTree = "<group>"; };
 		0601DE23223DBC4F00CFBDE3 /* Identifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Identifier.swift; sourceTree = "<group>"; };
+		0601DE25223EA98800CFBDE3 /* CustomTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextField.swift; sourceTree = "<group>"; };
+		0601DE28223EAF2400CFBDE3 /* EntryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryCell.swift; sourceTree = "<group>"; };
+		0601DE29223EAF2400CFBDE3 /* EntryCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EntryCell.xib; sourceTree = "<group>"; };
 		060C4D10221F425600B0BB07 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		060C4D12222047AC00B0BB07 /* JUICE_Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = JUICE_Regular.ttf; sourceTree = "<group>"; };
 		060C4D14222047BA00B0BB07 /* Library 3 am.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Library 3 am.otf"; sourceTree = "<group>"; };
@@ -102,7 +108,9 @@
 		0601DDE0222EFA1400CFBDE3 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				0601DE27223EAE6C00CFBDE3 /* EntryCell */,
 				0601DDE1222EFA7F00CFBDE3 /* LightButton.swift */,
+				0601DE25223EA98800CFBDE3 /* CustomTextField.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -113,6 +121,15 @@
 				0601DE23223DBC4F00CFBDE3 /* Identifier.swift */,
 			);
 			path = Helpers;
+			sourceTree = "<group>";
+		};
+		0601DE27223EAE6C00CFBDE3 /* EntryCell */ = {
+			isa = PBXGroup;
+			children = (
+				0601DE28223EAF2400CFBDE3 /* EntryCell.swift */,
+				0601DE29223EAF2400CFBDE3 /* EntryCell.xib */,
+			);
+			path = EntryCell;
 			sourceTree = "<group>";
 		};
 		060C4D1A2227107C00B0BB07 /* Models */ = {
@@ -286,6 +303,7 @@
 			files = (
 				060C4D13222047AC00B0BB07 /* JUICE_Regular.ttf in Resources */,
 				064A01CC221C6388001AE3AF /* Icons.xcassets in Resources */,
+				0601DE2B223EAF2400CFBDE3 /* EntryCell.xib in Resources */,
 				064A01A5221B3BEF001AE3AF /* LaunchScreen.storyboard in Resources */,
 				060C4D11221F425600B0BB07 /* Images.xcassets in Resources */,
 				064A01BB221B4CE2001AE3AF /* Colors.xcassets in Resources */,
@@ -311,9 +329,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0601DE26223EA98800CFBDE3 /* CustomTextField.swift in Sources */,
 				064A01CA221B5C0E001AE3AF /* Font.swift in Sources */,
 				064A019B221B3BED001AE3AF /* AppDelegate.swift in Sources */,
 				060C4D232227556600B0BB07 /* ChoreViewModel.swift in Sources */,
+				0601DE2A223EAF2400CFBDE3 /* EntryCell.swift in Sources */,
 				064A01BE221B53AD001AE3AF /* ThemeColor.swift in Sources */,
 				0601DDDE222EF45D00CFBDE3 /* HomeViewController.swift in Sources */,
 				060C4D1C222710C100B0BB07 /* PlayerModel.swift in Sources */,

--- a/SparkleSpin.xcodeproj/project.pbxproj
+++ b/SparkleSpin.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		0601DE26223EA98800CFBDE3 /* CustomTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0601DE25223EA98800CFBDE3 /* CustomTextField.swift */; };
 		0601DE2A223EAF2400CFBDE3 /* EntryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0601DE28223EAF2400CFBDE3 /* EntryCell.swift */; };
 		0601DE2B223EAF2400CFBDE3 /* EntryCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0601DE29223EAF2400CFBDE3 /* EntryCell.xib */; };
+		0601DE2D22402C0F00CFBDE3 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0601DE2C22402C0F00CFBDE3 /* Constants.swift */; };
 		060C4D11221F425600B0BB07 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 060C4D10221F425600B0BB07 /* Images.xcassets */; };
 		060C4D13222047AC00B0BB07 /* JUICE_Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 060C4D12222047AC00B0BB07 /* JUICE_Regular.ttf */; };
 		060C4D15222047BA00B0BB07 /* Library 3 am.otf in Resources */ = {isa = PBXBuildFile; fileRef = 060C4D14222047BA00B0BB07 /* Library 3 am.otf */; };
@@ -53,6 +54,7 @@
 		0601DE25223EA98800CFBDE3 /* CustomTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextField.swift; sourceTree = "<group>"; };
 		0601DE28223EAF2400CFBDE3 /* EntryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryCell.swift; sourceTree = "<group>"; };
 		0601DE29223EAF2400CFBDE3 /* EntryCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EntryCell.xib; sourceTree = "<group>"; };
+		0601DE2C22402C0F00CFBDE3 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		060C4D10221F425600B0BB07 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		060C4D12222047AC00B0BB07 /* JUICE_Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = JUICE_Regular.ttf; sourceTree = "<group>"; };
 		060C4D14222047BA00B0BB07 /* Library 3 am.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Library 3 am.otf"; sourceTree = "<group>"; };
@@ -119,6 +121,7 @@
 			isa = PBXGroup;
 			children = (
 				0601DE23223DBC4F00CFBDE3 /* Identifier.swift */,
+				0601DE2C22402C0F00CFBDE3 /* Constants.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -334,6 +337,7 @@
 				064A019B221B3BED001AE3AF /* AppDelegate.swift in Sources */,
 				060C4D232227556600B0BB07 /* ChoreViewModel.swift in Sources */,
 				0601DE2A223EAF2400CFBDE3 /* EntryCell.swift in Sources */,
+				0601DE2D22402C0F00CFBDE3 /* Constants.swift in Sources */,
 				064A01BE221B53AD001AE3AF /* ThemeColor.swift in Sources */,
 				0601DDDE222EF45D00CFBDE3 /* HomeViewController.swift in Sources */,
 				060C4D1C222710C100B0BB07 /* PlayerModel.swift in Sources */,

--- a/SparkleSpin.xcodeproj/project.pbxproj
+++ b/SparkleSpin.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		0601DDDE222EF45D00CFBDE3 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0601DDDD222EF45D00CFBDE3 /* HomeViewController.swift */; };
 		0601DDE2222EFA7F00CFBDE3 /* LightButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0601DDE1222EFA7F00CFBDE3 /* LightButton.swift */; };
+		0601DE21223DBA1500CFBDE3 /* PlayerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0601DE20223DBA1500CFBDE3 /* PlayerViewController.swift */; };
+		0601DE24223DBC4F00CFBDE3 /* Identifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0601DE23223DBC4F00CFBDE3 /* Identifier.swift */; };
 		060C4D11221F425600B0BB07 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 060C4D10221F425600B0BB07 /* Images.xcassets */; };
 		060C4D13222047AC00B0BB07 /* JUICE_Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 060C4D12222047AC00B0BB07 /* JUICE_Regular.ttf */; };
 		060C4D15222047BA00B0BB07 /* Library 3 am.otf in Resources */ = {isa = PBXBuildFile; fileRef = 060C4D14222047BA00B0BB07 /* Library 3 am.otf */; };
@@ -43,6 +45,8 @@
 /* Begin PBXFileReference section */
 		0601DDDD222EF45D00CFBDE3 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		0601DDE1222EFA7F00CFBDE3 /* LightButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightButton.swift; sourceTree = "<group>"; };
+		0601DE20223DBA1500CFBDE3 /* PlayerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerViewController.swift; sourceTree = "<group>"; };
+		0601DE23223DBC4F00CFBDE3 /* Identifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Identifier.swift; sourceTree = "<group>"; };
 		060C4D10221F425600B0BB07 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		060C4D12222047AC00B0BB07 /* JUICE_Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = JUICE_Regular.ttf; sourceTree = "<group>"; };
 		060C4D14222047BA00B0BB07 /* Library 3 am.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Library 3 am.otf"; sourceTree = "<group>"; };
@@ -90,6 +94,7 @@
 			isa = PBXGroup;
 			children = (
 				0601DDDD222EF45D00CFBDE3 /* HomeViewController.swift */,
+				0601DE20223DBA1500CFBDE3 /* PlayerViewController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -100,6 +105,14 @@
 				0601DDE1222EFA7F00CFBDE3 /* LightButton.swift */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		0601DE22223DBAC300CFBDE3 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				0601DE23223DBC4F00CFBDE3 /* Identifier.swift */,
+			);
+			path = Helpers;
 			sourceTree = "<group>";
 		};
 		060C4D1A2227107C00B0BB07 /* Models */ = {
@@ -141,6 +154,7 @@
 		064A0199221B3BED001AE3AF /* SparkleSpin */ = {
 			isa = PBXGroup;
 			children = (
+				0601DE22223DBAC300CFBDE3 /* Helpers */,
 				0601DDE0222EFA1400CFBDE3 /* Views */,
 				0601DDDC222EF2BE00CFBDE3 /* Controllers */,
 				060C4D1D22271E3E00B0BB07 /* ViewModels */,
@@ -304,8 +318,10 @@
 				0601DDDE222EF45D00CFBDE3 /* HomeViewController.swift in Sources */,
 				060C4D1C222710C100B0BB07 /* PlayerModel.swift in Sources */,
 				060C4D21222754D400B0BB07 /* ChoreModel.swift in Sources */,
+				0601DE24223DBC4F00CFBDE3 /* Identifier.swift in Sources */,
 				060C4D1F22271E6800B0BB07 /* PlayerViewModel.swift in Sources */,
 				0601DDE2222EFA7F00CFBDE3 /* LightButton.swift in Sources */,
+				0601DE21223DBA1500CFBDE3 /* PlayerViewController.swift in Sources */,
 				064A01CE221C77A3001AE3AF /* Image.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SparkleSpin/AppDelegate.swift
+++ b/SparkleSpin/AppDelegate.swift
@@ -51,10 +51,11 @@ extension AppDelegate {
         let navigationBarAppearance = UINavigationBar.appearance()
         let attributes = [
             NSAttributedString.Key.foregroundColor: ThemeColor.Light.secondaryColor,
-            NSAttributedString.Key.font: Font.mainBodyFont
+            NSAttributedString.Key.font: Font.wheelBodyFont
         ]
         navigationBarAppearance.barTintColor = ThemeColor.Light.primaryColor
-        navigationBarAppearance.tintColor = ThemeColor.Light.secondaryColor
+        navigationBarAppearance.tintColor = ThemeColor.Light.accentColorOne
         navigationBarAppearance.titleTextAttributes = attributes as [NSAttributedString.Key : Any]
+        navigationBarAppearance.shadowImage = UIImage()
     }
 }

--- a/SparkleSpin/AppDelegate.swift
+++ b/SparkleSpin/AppDelegate.swift
@@ -16,6 +16,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
+        styleNavigationBar()
         return true
     }
 
@@ -44,3 +45,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 }
 
+extension AppDelegate {
+    
+    func styleNavigationBar() {
+        let navigationBarAppearance = UINavigationBar.appearance()
+        let attributes = [
+            NSAttributedString.Key.foregroundColor: ThemeColor.Light.secondaryColor,
+            NSAttributedString.Key.font: Font.mainBodyFont
+        ]
+        navigationBarAppearance.barTintColor = ThemeColor.Light.primaryColor
+        navigationBarAppearance.tintColor = ThemeColor.Light.secondaryColor
+        navigationBarAppearance.titleTextAttributes = attributes as [NSAttributedString.Key : Any]
+    }
+}

--- a/SparkleSpin/Base.lproj/Main.storyboard
+++ b/SparkleSpin/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="WW7-XB-d2J">
     <device id="retina5_9" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -44,7 +44,7 @@
                                 </state>
                                 <connections>
                                     <action selector="startButtonIsTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="V4m-cD-5pY"/>
-                                    <segue destination="kfy-vz-fa5" kind="presentation" identifier="homeToPlayer" id="kbu-Wi-p49"/>
+                                    <segue destination="kfy-vz-fa5" kind="show" identifier="homeToPlayer" id="kbu-Wi-p49"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -58,10 +58,11 @@
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
+                    <navigationItem key="navigationItem" id="UUr-IP-MQS"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4" y="21"/>
+            <point key="canvasLocation" x="946.39999999999998" y="20.689655172413794"/>
         </scene>
         <!--Player View Controller-->
         <scene sceneID="aAc-bA-5PK">
@@ -76,7 +77,25 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="DgJ-bS-OHE" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1231" y="21"/>
+            <point key="canvasLocation" x="2172" y="20.689655172413794"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="iHK-oA-eRe">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="WW7-XB-d2J" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="1xN-Lg-Vom">
+                        <rect key="frame" x="0.0" y="44" width="375" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="A2k-FC-bN7"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="bAt-Oc-4qF" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4" y="20.689655172413794"/>
         </scene>
     </scenes>
     <resources>

--- a/SparkleSpin/Base.lproj/Main.storyboard
+++ b/SparkleSpin/Base.lproj/Main.storyboard
@@ -36,7 +36,7 @@
                                 <color key="backgroundColor" name="LightColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="58" id="hXg-oA-lSx"/>
-                                    <constraint firstAttribute="width" constant="319" id="m2u-hF-gNR"/>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="319" id="m2u-hF-gNR"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" name="LIBRARY3AM" family="LIBRARY 3 AM" pointSize="32"/>
                                 <state key="normal" title="Start!">
@@ -72,7 +72,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="singleLineEtched" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Ae2-XG-8uP">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Ae2-XG-8uP">
                                 <rect key="frame" x="10" y="88" width="355" height="690"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </tableView>

--- a/SparkleSpin/Base.lproj/Main.storyboard
+++ b/SparkleSpin/Base.lproj/Main.storyboard
@@ -44,6 +44,7 @@
                                 </state>
                                 <connections>
                                     <action selector="startButtonIsTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="V4m-cD-5pY"/>
+                                    <segue destination="kfy-vz-fa5" kind="presentation" identifier="homeToPlayer" id="kbu-Wi-p49"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -60,6 +61,22 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="4" y="21"/>
+        </scene>
+        <!--Player View Controller-->
+        <scene sceneID="aAc-bA-5PK">
+            <objects>
+                <viewController id="kfy-vz-fa5" customClass="PlayerViewController" customModule="SparkleSpin" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="ljL-0M-Jri">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <viewLayoutGuide key="safeArea" id="fOo-al-RXF"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="DgJ-bS-OHE" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1231" y="21"/>
         </scene>
     </scenes>
     <resources>

--- a/SparkleSpin/Base.lproj/Main.storyboard
+++ b/SparkleSpin/Base.lproj/Main.storyboard
@@ -71,9 +71,24 @@
                     <view key="view" contentMode="scaleToFill" id="ljL-0M-Jri">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Ae2-XG-8uP">
+                                <rect key="frame" x="10" y="88" width="355" height="690"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </tableView>
+                        </subviews>
                         <color key="backgroundColor" name="LightColor"/>
+                        <constraints>
+                            <constraint firstItem="fOo-al-RXF" firstAttribute="trailing" secondItem="Ae2-XG-8uP" secondAttribute="trailing" constant="10" id="8ia-UE-BSU"/>
+                            <constraint firstItem="Ae2-XG-8uP" firstAttribute="leading" secondItem="fOo-al-RXF" secondAttribute="leading" constant="10" id="kRb-Ll-168"/>
+                            <constraint firstItem="fOo-al-RXF" firstAttribute="bottom" secondItem="Ae2-XG-8uP" secondAttribute="bottom" id="r31-Jk-MdS"/>
+                            <constraint firstItem="Ae2-XG-8uP" firstAttribute="top" secondItem="fOo-al-RXF" secondAttribute="top" id="vZK-iW-BcA"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="fOo-al-RXF"/>
                     </view>
+                    <connections>
+                        <outlet property="playerTableView" destination="Ae2-XG-8uP" id="elp-ky-kcC"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="DgJ-bS-OHE" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/SparkleSpin/Base.lproj/Main.storyboard
+++ b/SparkleSpin/Base.lproj/Main.storyboard
@@ -72,7 +72,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Ae2-XG-8uP">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="singleLineEtched" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Ae2-XG-8uP">
                                 <rect key="frame" x="10" y="88" width="355" height="690"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </tableView>

--- a/SparkleSpin/Base.lproj/Main.storyboard
+++ b/SparkleSpin/Base.lproj/Main.storyboard
@@ -71,7 +71,7 @@
                     <view key="view" contentMode="scaleToFill" id="ljL-0M-Jri">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="backgroundColor" name="LightColor"/>
                         <viewLayoutGuide key="safeArea" id="fOo-al-RXF"/>
                     </view>
                 </viewController>
@@ -87,6 +87,7 @@
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="1xN-Lg-Vom">
                         <rect key="frame" x="0.0" y="44" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <color key="tintColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>

--- a/SparkleSpin/Controllers/HomeViewController.swift
+++ b/SparkleSpin/Controllers/HomeViewController.swift
@@ -17,6 +17,7 @@ class HomeViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(true, animated: animated)
+        navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
     }
     
     override func viewWillDisappear(_ animated: Bool) {

--- a/SparkleSpin/Controllers/HomeViewController.swift
+++ b/SparkleSpin/Controllers/HomeViewController.swift
@@ -10,10 +10,6 @@ import UIKit
 
 class HomeViewController: UIViewController {
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-    }
-    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(true, animated: animated)

--- a/SparkleSpin/Controllers/HomeViewController.swift
+++ b/SparkleSpin/Controllers/HomeViewController.swift
@@ -14,6 +14,16 @@ class HomeViewController: UIViewController {
         super.viewDidLoad()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: animated)
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.setNavigationBarHidden(false, animated: animated)
+    }
+    
     
     @IBAction func startButtonIsTapped(_ sender: LightButton) {
         sender.animateButton()

--- a/SparkleSpin/Controllers/PlayerViewController.swift
+++ b/SparkleSpin/Controllers/PlayerViewController.swift
@@ -28,6 +28,8 @@ class PlayerViewController: UIViewController {
     private func setupTableView() {
         playerTableView.dataSource = self
         playerTableView.delegate = self
+        playerTableView.backgroundColor = ThemeColor.Light.primaryColor
+        playerTableView.separatorStyle = .none
         playerTableView.rowHeight = UITableView.automaticDimension
         playerTableView.estimatedRowHeight = 200
         playerTableView.tableFooterView = UIView()
@@ -43,7 +45,7 @@ extension PlayerViewController: UITableViewDataSource, UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 3
+        return 1
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/SparkleSpin/Controllers/PlayerViewController.swift
+++ b/SparkleSpin/Controllers/PlayerViewController.swift
@@ -9,14 +9,46 @@
 import UIKit
 
 class PlayerViewController: UIViewController {
+    
+    @IBOutlet weak var playerTableView: UITableView!
+    
 
     override func viewDidLoad() {
         super.viewDidLoad()
         setNavigationBarTitle()
+        registerNib()
+        playerTableView.dataSource = self
+        playerTableView.delegate = self
+        playerTableView.rowHeight = UITableView.automaticDimension
+        playerTableView.estimatedRowHeight = 200
+    
     }
     
     private func setNavigationBarTitle() {
         navigationItem.title = "Choose Players!"
     }
 
+}
+
+extension PlayerViewController: UITableViewDataSource, UITableViewDelegate {
+    
+    func registerNib() {
+        let entryCell = UINib(nibName: NibID.entryCell, bundle: nil)
+        playerTableView.register(entryCell, forCellReuseIdentifier: CellID.entryCell)
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 3
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let entryCell = tableView.dequeueReusableCell(withIdentifier: CellID.entryCell, for: indexPath) as? EntryCell else { fatalError("Fatal error: No cell") }
+        return entryCell
+    }
+    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 100
+    }
+    
+    
 }

--- a/SparkleSpin/Controllers/PlayerViewController.swift
+++ b/SparkleSpin/Controllers/PlayerViewController.swift
@@ -17,16 +17,20 @@ class PlayerViewController: UIViewController {
         super.viewDidLoad()
         setNavigationBarTitle()
         registerNib()
-        playerTableView.dataSource = self
-        playerTableView.delegate = self
-        playerTableView.rowHeight = UITableView.automaticDimension
-        playerTableView.estimatedRowHeight = 200
-        playerTableView.tableFooterView = UIView()
+        setupTableView()
     
     }
     
     private func setNavigationBarTitle() {
         navigationItem.title = "Choose Players!"
+    }
+    
+    private func setupTableView() {
+        playerTableView.dataSource = self
+        playerTableView.delegate = self
+        playerTableView.rowHeight = UITableView.automaticDimension
+        playerTableView.estimatedRowHeight = 200
+        playerTableView.tableFooterView = UIView()
     }
 
 }

--- a/SparkleSpin/Controllers/PlayerViewController.swift
+++ b/SparkleSpin/Controllers/PlayerViewController.swift
@@ -31,7 +31,7 @@ class PlayerViewController: UIViewController {
         playerTableView.backgroundColor = ThemeColor.Light.primaryColor
         playerTableView.separatorStyle = .none
         playerTableView.rowHeight = UITableView.automaticDimension
-        playerTableView.estimatedRowHeight = 200
+        playerTableView.estimatedRowHeight = CGFloat(Constants.estimatedRowHeight)
         playerTableView.tableFooterView = UIView()
     }
 
@@ -54,7 +54,7 @@ extension PlayerViewController: UITableViewDataSource, UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 100
+        return CGFloat(Constants.entryCellRowHeight)
     }
     
     

--- a/SparkleSpin/Controllers/PlayerViewController.swift
+++ b/SparkleSpin/Controllers/PlayerViewController.swift
@@ -21,6 +21,7 @@ class PlayerViewController: UIViewController {
         playerTableView.delegate = self
         playerTableView.rowHeight = UITableView.automaticDimension
         playerTableView.estimatedRowHeight = 200
+        playerTableView.tableFooterView = UIView()
     
     }
     

--- a/SparkleSpin/Controllers/PlayerViewController.swift
+++ b/SparkleSpin/Controllers/PlayerViewController.swift
@@ -12,19 +12,16 @@ class PlayerViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        setNavigationBarTitle()
     }
-    */
+    
+    private func setNavigationBarTitle() {
+        let navigationBar = navigationController?.navigationBar
+        navigationBar?.topItem?.title = "Choose Players!"
+    }
 
 }

--- a/SparkleSpin/Controllers/PlayerViewController.swift
+++ b/SparkleSpin/Controllers/PlayerViewController.swift
@@ -1,0 +1,30 @@
+//
+//  PlayerViewController.swift
+//  SparkleSpin
+//
+//  Created by Britney Smith on 3/16/19.
+//  Copyright © 2019 Britney Smith. All rights reserved.
+//
+
+import UIKit
+
+class PlayerViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/SparkleSpin/Controllers/PlayerViewController.swift
+++ b/SparkleSpin/Controllers/PlayerViewController.swift
@@ -12,16 +12,11 @@ class PlayerViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-    }
-    
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
         setNavigationBarTitle()
     }
     
     private func setNavigationBarTitle() {
-        let navigationBar = navigationController?.navigationBar
-        navigationBar?.topItem?.title = "Choose Players!"
+        navigationItem.title = "Choose Players!"
     }
 
 }

--- a/SparkleSpin/Helpers/Constants.swift
+++ b/SparkleSpin/Helpers/Constants.swift
@@ -1,0 +1,12 @@
+//
+//  Constants.swift
+//  SparkleSpin
+//
+//  Created by Britney Smith on 3/18/19.
+//  Copyright © 2019 Britney Smith. All rights reserved.
+//
+
+enum Constants {
+    static let entryCellRowHeight = 100
+    static let estimatedRowHeight = 200
+}

--- a/SparkleSpin/Helpers/Identifier.swift
+++ b/SparkleSpin/Helpers/Identifier.swift
@@ -1,0 +1,18 @@
+//
+//  Identifier.swift
+//  SparkleSpin
+//
+//  Created by Britney Smith on 3/16/19.
+//  Copyright © 2019 Britney Smith. All rights reserved.
+//
+
+enum Identifier {
+    case homeToPlayer
+    
+    var segueID: String {
+        switch self {
+        case .homeToPlayer:
+            return "homeToPlayer"
+        }
+    }
+}

--- a/SparkleSpin/Helpers/Identifier.swift
+++ b/SparkleSpin/Helpers/Identifier.swift
@@ -6,13 +6,14 @@
 //  Copyright © 2019 Britney Smith. All rights reserved.
 //
 
-enum Identifier {
-    case homeToPlayer
-    
-    var segueID: String {
-        switch self {
-        case .homeToPlayer:
-            return "homeToPlayer"
-        }
-    }
+struct SegueID {
+    static let homeToPlayer = "homeToPlayer"
+}
+
+struct CellID {
+    static let entryCell = "EntryCell"
+}
+
+struct NibID {
+    static let entryCell = "EntryCell"
 }

--- a/SparkleSpin/Views/CustomTextField.swift
+++ b/SparkleSpin/Views/CustomTextField.swift
@@ -12,18 +12,7 @@ class CustomTextField: UITextField {
     
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-        underline()
-    }
-    
-    private func underline() {
-        let border = CALayer()
-        let width = CGFloat(1.25)
-        let customBorderColor = ThemeColor.Light.accentColorOne
-        
-        border.borderColor = customBorderColor?.cgColor
-        border.frame = CGRect(x: 0, y: frame.size.height - width, width: frame.size.width, height: frame.size.height)
-        border.borderWidth = width
-        layer.addSublayer(border)
-        layer.masksToBounds = true
+        font = Font.wheelBodyFont
+        becomeFirstResponder()
     }
 }

--- a/SparkleSpin/Views/CustomTextField.swift
+++ b/SparkleSpin/Views/CustomTextField.swift
@@ -12,7 +12,12 @@ class CustomTextField: UITextField {
     
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-        font = Font.wheelBodyFont
+        styleTextField()
         becomeFirstResponder()
+    }
+    
+    private func styleTextField() {
+        font = Font.wheelBodyFont
+        tintColor = ThemeColor.Light.accentColorOne
     }
 }

--- a/SparkleSpin/Views/CustomTextField.swift
+++ b/SparkleSpin/Views/CustomTextField.swift
@@ -1,0 +1,29 @@
+//
+//  CustomTextField.swift
+//  SparkleSpin
+//
+//  Created by Britney Smith on 3/17/19.
+//  Copyright © 2019 Britney Smith. All rights reserved.
+//
+
+import UIKit
+
+class CustomTextField: UITextField {
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        underline()
+    }
+    
+    private func underline() {
+        let border = CALayer()
+        let width = CGFloat(1.25)
+        let customBorderColor = ThemeColor.Light.accentColorOne
+        
+        border.borderColor = customBorderColor?.cgColor
+        border.frame = CGRect(x: 0, y: frame.size.height - width, width: frame.size.width, height: frame.size.height)
+        border.borderWidth = width
+        layer.addSublayer(border)
+        layer.masksToBounds = true
+    }
+}

--- a/SparkleSpin/Views/EntryCell/EntryCell.swift
+++ b/SparkleSpin/Views/EntryCell/EntryCell.swift
@@ -1,0 +1,15 @@
+//
+//  EntryCell.swift
+//  SparkleSpin
+//
+//  Created by Britney Smith on 3/17/19.
+//  Copyright © 2019 Britney Smith. All rights reserved.
+//
+
+import UIKit
+
+class EntryCell: UITableViewCell {
+
+   
+    
+}

--- a/SparkleSpin/Views/EntryCell/EntryCell.xib
+++ b/SparkleSpin/Views/EntryCell/EntryCell.xib
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="EntryCell" customModule="SparkleSpin" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ch7-K8-Dai">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                        <subviews>
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Enter here" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="5Ve-R2-0zQ" customClass="CustomTextField" customModule="SparkleSpin" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                <nil key="textColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                        </subviews>
+                    </stackView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="Ch7-K8-Dai" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="8Or-XN-f9H"/>
+                    <constraint firstItem="Ch7-K8-Dai" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="aWu-Vo-4cb"/>
+                    <constraint firstAttribute="trailing" secondItem="Ch7-K8-Dai" secondAttribute="trailing" id="cxh-Zz-us9"/>
+                    <constraint firstAttribute="bottom" secondItem="Ch7-K8-Dai" secondAttribute="bottom" id="q2s-sb-2O3"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/SparkleSpin/Views/EntryCell/EntryCell.xib
+++ b/SparkleSpin/Views/EntryCell/EntryCell.xib
@@ -6,39 +6,63 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="EntryCell" customModule="SparkleSpin" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="EntryCell" id="KGk-i7-Jjw" customClass="EntryCell" customModule="SparkleSpin" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="100"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="99.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ch7-K8-Dai">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                        <rect key="frame" x="10" y="10" width="300" height="79.5"/>
                         <subviews>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Enter here" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="5Ve-R2-0zQ" customClass="CustomTextField" customModule="SparkleSpin" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
-                                <nil key="textColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="wQ6-ib-Aln">
+                                <rect key="frame" x="0.0" y="0.0" width="300" height="79.5"/>
+                                <subviews>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Enter here" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="5Ve-R2-0zQ" customClass="CustomTextField" customModule="SparkleSpin" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="0.0" width="300" height="77.5"/>
+                                        <nil key="textColor"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uNh-YA-1XA">
+                                        <rect key="frame" x="0.0" y="77.5" width="300" height="2"/>
+                                        <color key="backgroundColor" name="Violet"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="2" id="x7c-Nj-D7F"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                            </stackView>
                         </subviews>
+                        <constraints>
+                            <constraint firstItem="wQ6-ib-Aln" firstAttribute="top" secondItem="Ch7-K8-Dai" secondAttribute="top" id="Cw8-hd-0KS"/>
+                            <constraint firstAttribute="bottom" secondItem="wQ6-ib-Aln" secondAttribute="bottom" id="PVA-0U-aeW"/>
+                            <constraint firstAttribute="trailing" secondItem="wQ6-ib-Aln" secondAttribute="trailing" id="dTi-bf-0sL"/>
+                            <constraint firstItem="wQ6-ib-Aln" firstAttribute="leading" secondItem="Ch7-K8-Dai" secondAttribute="leading" id="lDQ-r4-61k"/>
+                        </constraints>
                     </stackView>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="Ch7-K8-Dai" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="8Or-XN-f9H"/>
-                    <constraint firstItem="Ch7-K8-Dai" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="aWu-Vo-4cb"/>
-                    <constraint firstAttribute="trailing" secondItem="Ch7-K8-Dai" secondAttribute="trailing" id="cxh-Zz-us9"/>
-                    <constraint firstAttribute="bottom" secondItem="Ch7-K8-Dai" secondAttribute="bottom" id="q2s-sb-2O3"/>
+                    <constraint firstItem="Ch7-K8-Dai" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="10" id="8Or-XN-f9H"/>
+                    <constraint firstItem="Ch7-K8-Dai" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="10" id="aWu-Vo-4cb"/>
+                    <constraint firstAttribute="trailing" secondItem="Ch7-K8-Dai" secondAttribute="trailing" constant="10" id="cxh-Zz-us9"/>
+                    <constraint firstAttribute="bottom" secondItem="Ch7-K8-Dai" secondAttribute="bottom" constant="10" id="q2s-sb-2O3"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
         </tableViewCell>
     </objects>
+    <resources>
+        <namedColor name="Violet">
+            <color red="0.38823529411764707" green="0.047058823529411764" blue="0.90588235294117647" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+        </namedColor>
+    </resources>
 </document>

--- a/SparkleSpin/Views/EntryCell/EntryCell.xib
+++ b/SparkleSpin/Views/EntryCell/EntryCell.xib
@@ -26,7 +26,7 @@
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="wQ6-ib-Aln">
                                 <rect key="frame" x="0.0" y="0.0" width="300" height="79.5"/>
                                 <subviews>
-                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Enter here" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="5Ve-R2-0zQ" customClass="CustomTextField" customModule="SparkleSpin" customModuleProvider="target">
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Enter here" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="5Ve-R2-0zQ" customClass="CustomTextField" customModule="SparkleSpin" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="0.0" width="300" height="77.5"/>
                                         <nil key="textColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="16"/>


### PR DESCRIPTION
## What you did :question:
This PR includes the preliminary work to build the full 'Choose Players' screen: A navigation controller and a tableview to display a custom cell that includes a custom textfield.

## How to test it :microscope:
1. Check out this branch
2. Run the app
3. On the Home screen, tap the 'Start' button
4. Note that a screen with the title 'Choose Players!' appears with a single text field (see screenshot)
5. Tap the 'Back' button represented the single "chevron" icon (the line arrow that faces left)
6. Note that the Home screen is displayed (see screenshot)

## Any background context you want to provide? :question:
On the 'Choose Players!' screen, I plan to add an 'Add' button that will add rows to the tableview (to enter more names as needed by the user).


## Screenshots (if applicable) :camera:
Not shown: Launch screen
![sparkle-spin-pr-player-screen](https://user-images.githubusercontent.com/8409475/54537152-67e50700-4968-11e9-9d54-b61b52d5e962.gif)
