### PR TITLE
Add player tests

### DIFF
--- a/SparkleSpin.xcodeproj/project.pbxproj
+++ b/SparkleSpin.xcodeproj/project.pbxproj
@@ -22,7 +22,7 @@
 		060C4D17222047C500B0BB07 /* PoetsenOne-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 060C4D16222047C500B0BB07 /* PoetsenOne-Regular.otf */; };
 		060C4D19222047D100B0BB07 /* saxmono.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 060C4D18222047D100B0BB07 /* saxmono.ttf */; };
 		060C4D1C222710C100B0BB07 /* PlayerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 060C4D1B222710C100B0BB07 /* PlayerModel.swift */; };
-		060C4D1F22271E6800B0BB07 /* PlayerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 060C4D1E22271E6800B0BB07 /* PlayerViewModel.swift */; };
+		060C4D1F22271E6800B0BB07 /* PlayerListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 060C4D1E22271E6800B0BB07 /* PlayerListViewModel.swift */; };
 		060C4D21222754D400B0BB07 /* ChoreModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 060C4D20222754D400B0BB07 /* ChoreModel.swift */; };
 		060C4D232227556600B0BB07 /* ChoreViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 060C4D222227556600B0BB07 /* ChoreViewModel.swift */; };
 		064A019B221B3BED001AE3AF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 064A019A221B3BED001AE3AF /* AppDelegate.swift */; };
@@ -63,7 +63,7 @@
 		060C4D16222047C500B0BB07 /* PoetsenOne-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "PoetsenOne-Regular.otf"; sourceTree = "<group>"; };
 		060C4D18222047D100B0BB07 /* saxmono.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = saxmono.ttf; sourceTree = "<group>"; };
 		060C4D1B222710C100B0BB07 /* PlayerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerModel.swift; sourceTree = "<group>"; };
-		060C4D1E22271E6800B0BB07 /* PlayerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerViewModel.swift; sourceTree = "<group>"; };
+		060C4D1E22271E6800B0BB07 /* PlayerListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerListViewModel.swift; sourceTree = "<group>"; };
 		060C4D20222754D400B0BB07 /* ChoreModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChoreModel.swift; sourceTree = "<group>"; };
 		060C4D222227556600B0BB07 /* ChoreViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChoreViewModel.swift; sourceTree = "<group>"; };
 		064A0197221B3BED001AE3AF /* SparkleSpin.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SparkleSpin.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -150,7 +150,7 @@
 		060C4D1D22271E3E00B0BB07 /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
-				060C4D1E22271E6800B0BB07 /* PlayerViewModel.swift */,
+				060C4D1E22271E6800B0BB07 /* PlayerListViewModel.swift */,
 				060C4D222227556600B0BB07 /* ChoreViewModel.swift */,
 			);
 			name = ViewModels;
@@ -347,7 +347,7 @@
 				060C4D21222754D400B0BB07 /* ChoreModel.swift in Sources */,
 				0601DE2F2242913500CFBDE3 /* PlayerListModel.swift in Sources */,
 				0601DE24223DBC4F00CFBDE3 /* Identifier.swift in Sources */,
-				060C4D1F22271E6800B0BB07 /* PlayerViewModel.swift in Sources */,
+				060C4D1F22271E6800B0BB07 /* PlayerListViewModel.swift in Sources */,
 				0601DDE2222EFA7F00CFBDE3 /* LightButton.swift in Sources */,
 				0601DE21223DBA1500CFBDE3 /* PlayerViewController.swift in Sources */,
 				064A01CE221C77A3001AE3AF /* Image.swift in Sources */,

--- a/SparkleSpin.xcodeproj/project.pbxproj
+++ b/SparkleSpin.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		0601DE2A223EAF2400CFBDE3 /* EntryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0601DE28223EAF2400CFBDE3 /* EntryCell.swift */; };
 		0601DE2B223EAF2400CFBDE3 /* EntryCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0601DE29223EAF2400CFBDE3 /* EntryCell.xib */; };
 		0601DE2D22402C0F00CFBDE3 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0601DE2C22402C0F00CFBDE3 /* Constants.swift */; };
+		0601DE2F2242913500CFBDE3 /* PlayerListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0601DE2E2242913500CFBDE3 /* PlayerListModel.swift */; };
 		060C4D11221F425600B0BB07 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 060C4D10221F425600B0BB07 /* Images.xcassets */; };
 		060C4D13222047AC00B0BB07 /* JUICE_Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 060C4D12222047AC00B0BB07 /* JUICE_Regular.ttf */; };
 		060C4D15222047BA00B0BB07 /* Library 3 am.otf in Resources */ = {isa = PBXBuildFile; fileRef = 060C4D14222047BA00B0BB07 /* Library 3 am.otf */; };
@@ -55,6 +56,7 @@
 		0601DE28223EAF2400CFBDE3 /* EntryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryCell.swift; sourceTree = "<group>"; };
 		0601DE29223EAF2400CFBDE3 /* EntryCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EntryCell.xib; sourceTree = "<group>"; };
 		0601DE2C22402C0F00CFBDE3 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		0601DE2E2242913500CFBDE3 /* PlayerListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerListModel.swift; sourceTree = "<group>"; };
 		060C4D10221F425600B0BB07 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		060C4D12222047AC00B0BB07 /* JUICE_Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = JUICE_Regular.ttf; sourceTree = "<group>"; };
 		060C4D14222047BA00B0BB07 /* Library 3 am.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Library 3 am.otf"; sourceTree = "<group>"; };
@@ -140,6 +142,7 @@
 			children = (
 				060C4D1B222710C100B0BB07 /* PlayerModel.swift */,
 				060C4D20222754D400B0BB07 /* ChoreModel.swift */,
+				0601DE2E2242913500CFBDE3 /* PlayerListModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -342,6 +345,7 @@
 				0601DDDE222EF45D00CFBDE3 /* HomeViewController.swift in Sources */,
 				060C4D1C222710C100B0BB07 /* PlayerModel.swift in Sources */,
 				060C4D21222754D400B0BB07 /* ChoreModel.swift in Sources */,
+				0601DE2F2242913500CFBDE3 /* PlayerListModel.swift in Sources */,
 				0601DE24223DBC4F00CFBDE3 /* Identifier.swift in Sources */,
 				060C4D1F22271E6800B0BB07 /* PlayerViewModel.swift in Sources */,
 				0601DDE2222EFA7F00CFBDE3 /* LightButton.swift in Sources */,

--- a/SparkleSpin/Controllers/PlayerViewController.swift
+++ b/SparkleSpin/Controllers/PlayerViewController.swift
@@ -11,7 +11,6 @@ import UIKit
 class PlayerViewController: UIViewController {
     
     @IBOutlet weak var playerTableView: UITableView!
-    
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/SparkleSpin/Models/PlayerListModel.swift
+++ b/SparkleSpin/Models/PlayerListModel.swift
@@ -1,0 +1,21 @@
+//
+//  PlayerListModel.swift
+//  SparkleSpin
+//
+//  Created by Britney Smith on 3/20/19.
+//  Copyright © 2019 Britney Smith. All rights reserved.
+//
+
+class PlayerListModel {
+    var playerList: [PlayerModel]?
+    
+    init(playerList: [PlayerModel]?) {
+        self.playerList = playerList
+    }
+}
+
+extension PlayerListModel: Equatable {
+    static func == (lhs: PlayerListModel, rhs: PlayerListModel) -> Bool {
+        return lhs.playerList == rhs.playerList
+    }
+}

--- a/SparkleSpin/Models/PlayerModel.swift
+++ b/SparkleSpin/Models/PlayerModel.swift
@@ -24,10 +24,3 @@ extension PlayerModel: Equatable {
     }
 }
 
-extension PlayerModel: Hashable {
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(name)
-        hasher.combine(uuid)
-    }
-}
-

--- a/SparkleSpin/Models/PlayerModel.swift
+++ b/SparkleSpin/Models/PlayerModel.swift
@@ -15,3 +15,10 @@ class PlayerModel {
         self.name = name
     }
 }
+
+extension PlayerModel: Equatable {
+    static func == (lhs: PlayerModel, rhs: PlayerModel) -> Bool {
+        return lhs.name == rhs.name
+    }
+}
+

--- a/SparkleSpin/Models/PlayerModel.swift
+++ b/SparkleSpin/Models/PlayerModel.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2019 Britney Smith. All rights reserved.
 //
 
+import Foundation
+
 class PlayerModel {
     var name: String?
     var uuid: String?

--- a/SparkleSpin/Models/PlayerModel.swift
+++ b/SparkleSpin/Models/PlayerModel.swift
@@ -10,15 +10,24 @@ import Foundation
 
 class PlayerModel {
     var name: String?
+    var uuid: String?
     
     init(name: String?) {
         self.name = name
+        self.uuid = NSUUID().uuidString
     }
 }
 
 extension PlayerModel: Equatable {
     static func == (lhs: PlayerModel, rhs: PlayerModel) -> Bool {
-        return lhs.name == rhs.name
+        return lhs.name == rhs.name && lhs.uuid == rhs.uuid
+    }
+}
+
+extension PlayerModel: Hashable {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(name)
+        hasher.combine(uuid)
     }
 }
 

--- a/SparkleSpin/Models/PlayerModel.swift
+++ b/SparkleSpin/Models/PlayerModel.swift
@@ -14,7 +14,7 @@ class PlayerModel {
     
     init(name: String?) {
         self.name = name
-        self.uuid = NSUUID().uuidString
+        self.uuid = UUID().uuidString
     }
 }
 

--- a/SparkleSpin/PlayerListViewModel.swift
+++ b/SparkleSpin/PlayerListViewModel.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2019 Britney Smith. All rights reserved.
 //
 
-import Foundation
-
 class PlayerListViewModel {
     
     private let playerListModel: PlayerListModel

--- a/SparkleSpin/PlayerListViewModel.swift
+++ b/SparkleSpin/PlayerListViewModel.swift
@@ -17,10 +17,11 @@ class PlayerListViewModel {
         self.playerListModel = playerListModel
     }
     
-    func createPlayersWith(names nameStrings: [String]) {
+    func createPlayersWith(names nameStrings: [String]) -> [PlayerModel] {
         for name in nameStrings {
             let playerModel = PlayerModel(name: name)
             playerListModel.playerList?.append(playerModel)
         }
+        return playerListModel.playerList ?? []
     }
 }

--- a/SparkleSpin/PlayerListViewModel.swift
+++ b/SparkleSpin/PlayerListViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  PlayerViewModel.swift
+//  PlayerListViewModel.swift
 //  SparkleSpin
 //
 //  Created by Britney Smith on 2/27/19.
@@ -8,14 +8,12 @@
 
 import Foundation
 
-class PlayerViewModel {
+class PlayerListViewModel {
     
-    //private let playerModels: [PlayerModel]
     private let playerListModel: PlayerListModel
     var nameString: String? = nil
     
-    init(/*playerModels: [PlayerModel],*/ playerListModel: PlayerListModel) {
-        //self.playerModels = playerModels
+    init(playerListModel: PlayerListModel) {
         self.playerListModel = playerListModel
     }
     

--- a/SparkleSpin/PlayerListViewModel.swift
+++ b/SparkleSpin/PlayerListViewModel.swift
@@ -28,14 +28,10 @@ class PlayerListViewModel {
     }
     
     func deletePlayer(playerToDelete: PlayerModel) {
-        var playerSet = Set<PlayerModel>((playerListModel.playerList.map { $0 } ) ?? [])
-        
-        for player in playerSet {
+        for (index, player) in playerListModel.playerList?.enumerated() ?? [].enumerated() {
             if player == playerToDelete {
-                playerSet.remove(player)
+                playerListModel.playerList?.remove(at: index)
             }
         }
-        
-        playerListModel.playerList = Array(playerSet)
     }
 }

--- a/SparkleSpin/PlayerListViewModel.swift
+++ b/SparkleSpin/PlayerListViewModel.swift
@@ -28,10 +28,10 @@ class PlayerListViewModel {
     }
     
     func deletePlayer(playerToDelete: PlayerModel) {
-        for (index, player) in playerListModel.playerList?.enumerated() ?? [].enumerated() {
-            if player == playerToDelete {
-                playerListModel.playerList?.remove(at: index)
-            }
+        guard let playerDeleteIndex = playerListModel.playerList?.firstIndex(where: { $0 == playerToDelete }) else {
+            print("No such player")
+            return
         }
+        playerListModel.playerList?.remove(at: playerDeleteIndex)
     }
 }

--- a/SparkleSpin/PlayerListViewModel.swift
+++ b/SparkleSpin/PlayerListViewModel.swift
@@ -30,10 +30,14 @@ class PlayerListViewModel {
     }
     
     func deletePlayer(playerToDelete: PlayerModel) {
-        for (index, player) in playerListModel.playerList?.enumerated() ?? [].enumerated() {
+        var playerSet = Set<PlayerModel>((playerListModel.playerList.map { $0 } ) ?? [])
+        
+        for player in playerSet {
             if player == playerToDelete {
-                playerListModel.playerList?.remove(at: index)
+                playerSet.remove(player)
             }
-        } // use Set to have unique identifiers
+        }
+        
+        playerListModel.playerList = Array(playerSet)
     }
 }

--- a/SparkleSpin/PlayerListViewModel.swift
+++ b/SparkleSpin/PlayerListViewModel.swift
@@ -17,11 +17,23 @@ class PlayerListViewModel {
         self.playerListModel = playerListModel
     }
     
-    func createPlayersWith(names nameStrings: [String]) -> [PlayerModel] {
-        for name in nameStrings {
-            let playerModel = PlayerModel(name: name)
-            playerListModel.playerList?.append(playerModel)
-        }
+    func createPlayerWith(name: String) -> PlayerModel {
+        return PlayerModel(name: name)
+    }
+    
+    func addPlayerToPlayerList(player: PlayerModel) {
+        playerListModel.playerList?.append(player)
+    }
+    
+    func getPlayerList() -> [PlayerModel] {
         return playerListModel.playerList ?? []
+    }
+    
+    func deletePlayer(playerToDelete: PlayerModel) {
+        for (index, player) in playerListModel.playerList?.enumerated() ?? [].enumerated() {
+            if player == playerToDelete {
+                playerListModel.playerList?.remove(at: index)
+            }
+        } // use Set to have unique identifiers
     }
 }

--- a/SparkleSpin/PlayerViewModel.swift
+++ b/SparkleSpin/PlayerViewModel.swift
@@ -10,27 +10,19 @@ import Foundation
 
 class PlayerViewModel {
     
-    private let playerModels: [PlayerModel]
+    //private let playerModels: [PlayerModel]
     private let playerListModel: PlayerListModel
     var nameString: String? = nil
     
-    init(playerModels: [PlayerModel], playerListModel: PlayerListModel) {
-        self.playerModels = playerModels
+    init(/*playerModels: [PlayerModel],*/ playerListModel: PlayerListModel) {
+        //self.playerModels = playerModels
         self.playerListModel = playerListModel
     }
     
-    func updateProperties(nameStrings: [String]) {
-//        for playerModel in playerModels {
-//            playerModel.name = nameString
-//        }
-        
+    func createPlayersWith(names nameStrings: [String]) {
         for name in nameStrings {
             let playerModel = PlayerModel(name: name)
             playerListModel.playerList?.append(playerModel)
         }
-    }
-    
-    func addPlayerToPlayerList(player: PlayerModel) {
-        playerListModel.playerList?.append(player)
     }
 }

--- a/SparkleSpin/PlayerViewModel.swift
+++ b/SparkleSpin/PlayerViewModel.swift
@@ -10,17 +10,19 @@ import Foundation
 
 class PlayerViewModel {
     
-    private let playerModel: PlayerModel
+    private let playerModels: [PlayerModel]
     private let playerListModel: PlayerListModel
     var nameString: String? = nil
     
-    init(playerModel: PlayerModel, playerListModel: PlayerListModel) {
-        self.playerModel = playerModel
+    init(playerModels: [PlayerModel], playerListModel: PlayerListModel) {
+        self.playerModels = playerModels
         self.playerListModel = playerListModel
     }
     
     func updateProperties(nameString: String) {
-        playerModel.name = nameString
+        for playerModel in playerModels {
+            playerModel.name = nameString
+        }
     }
     
     func addPlayerToPlayerList(player: PlayerModel) {

--- a/SparkleSpin/PlayerViewModel.swift
+++ b/SparkleSpin/PlayerViewModel.swift
@@ -11,13 +11,19 @@ import Foundation
 class PlayerViewModel {
     
     private let playerModel: PlayerModel
+    private let playerListModel: PlayerListModel
     var nameString: String? = nil
     
-    init(playerModel: PlayerModel) {
+    init(playerModel: PlayerModel, playerListModel: PlayerListModel) {
         self.playerModel = playerModel
+        self.playerListModel = playerListModel
     }
     
     func updateProperties(nameString: String) {
         playerModel.name = nameString
+    }
+    
+    func addPlayerToPlayerList(player: PlayerModel) {
+        playerListModel.playerList?.append(player)
     }
 }

--- a/SparkleSpin/PlayerViewModel.swift
+++ b/SparkleSpin/PlayerViewModel.swift
@@ -19,9 +19,14 @@ class PlayerViewModel {
         self.playerListModel = playerListModel
     }
     
-    func updateProperties(nameString: String) {
-        for playerModel in playerModels {
-            playerModel.name = nameString
+    func updateProperties(nameStrings: [String]) {
+//        for playerModel in playerModels {
+//            playerModel.name = nameString
+//        }
+        
+        for name in nameStrings {
+            let playerModel = PlayerModel(name: name)
+            playerListModel.playerList?.append(playerModel)
         }
     }
     

--- a/SparkleSpinTests/ModelTests.swift
+++ b/SparkleSpinTests/ModelTests.swift
@@ -22,61 +22,136 @@ class ModelTests: XCTestCase {
     func testCreateOnePlayer() {
         // given
         let name = "Kevin"
-        let nameList = [name]
         
         let playerListModel = PlayerListModel(playerList: [])
         let playerListViewModel = PlayerListViewModel(playerListModel: playerListModel
         )
 
         // when
-        let _ = playerListViewModel.createPlayersWith(names: nameList)
+        let playerOne = playerListViewModel.createPlayerWith(name: name)
 
         // then
-        XCTAssertEqual(playerListModel.playerList,  [PlayerModel(name: "Kevin")])
+        XCTAssertEqual(playerOne,  PlayerModel(name: "Kevin"))
     }
-//
-//    func testCreateChore() {
-//        // given
-//        let choreName = "Washing dishes"
-//        let choreOneModel = ChoreModel(choreName: nil)
-//        let choreOneViewModel = ChoreViewModel(choreModel: choreOneModel)
-//
-//        // when
-//        choreOneViewModel.updateProperties(choreNameString: choreName)
-//
-//        // then
-//        XCTAssertEqual(choreOneModel.choreName, "Washing dishes")
-//    }
-//
-//    func testAddPlayerToPlayerList() {
-//        // given
-//        let name = "Kevin"
-//        let playerOneModel = PlayerModel(name: nil)
-//        let playerListModel = PlayerListModel(playerList: [])
-//        let playerOneViewModel = PlayerViewModel(playerModels: [playerOneModel], playerListModel: playerListModel
-//        )
-//
-//        playerOneViewModel.updateProperties(nameString: name)
-//
-//        // when
-//        playerOneViewModel.addPlayerToPlayerList(player: playerOneModel)
-//
-//        // then
-//        XCTAssertEqual(playerListModel.playerList, [PlayerModel(name: "Kevin")])
-//    }
     
     func testCreateTwoPlayers() {
         // given
         let nameOne = "Kevin"
         let nameTwo = "Lisa"
-        let nameList = [nameOne, nameTwo]
         
         let playerListModel = PlayerListModel(playerList: [])
         let playerListViewModel = PlayerListViewModel(playerListModel: playerListModel
         )
         
         // when
-        let _ = playerListViewModel.createPlayersWith(names: nameList)
+        let playerOne = playerListViewModel.createPlayerWith(name: nameOne)
+        let playerTwo = playerListViewModel.createPlayerWith(name: nameTwo)
+        
+        // then
+        XCTAssertEqual([playerOne, playerTwo], [PlayerModel(name: "Kevin"), PlayerModel(name: "Lisa")])
+    }
+    
+    func testAddOnePlayerToPlayerList() {
+        // given
+        let name = "Kevin"
+        
+        let playerListModel = PlayerListModel(playerList: [])
+        let playerListViewModel = PlayerListViewModel(playerListModel: playerListModel)
+        let playerOne = playerListViewModel.createPlayerWith(name: name)
+        
+        // when
+        playerListViewModel.addPlayerToPlayerList(player: playerOne)
+        
+        // then
+        XCTAssertEqual(playerListModel.playerList, [PlayerModel(name: "Kevin")])
+    }
+    
+    func testAddAnotherPlayerToPlayerList() {
+        // given
+        let nameOne = "Kevin"
+        let nameTwo = "Lisa"
+        
+        let playerListModel = PlayerListModel(playerList: [])
+        let playerListViewModel = PlayerListViewModel(playerListModel: playerListModel
+        )
+        
+        let playerOne = playerListViewModel.createPlayerWith(name: nameOne)
+        playerListViewModel.addPlayerToPlayerList(player: playerOne)
+        
+        // when
+        let playerTwo = playerListViewModel.createPlayerWith(name: nameTwo)
+        playerListViewModel.addPlayerToPlayerList(player: playerTwo)
+        
+        // then
+        XCTAssertEqual(playerListModel.playerList, [PlayerModel(name: "Kevin"), PlayerModel(name: "Lisa")])
+        
+    }
+    
+    func testGetPlayerList() {
+        // given
+        let nameOne = "Kevin"
+        let nameTwo = "Lisa"
+        
+        let playerListModel = PlayerListModel(playerList: [])
+        let playerListViewModel = PlayerListViewModel(playerListModel: playerListModel
+        )
+        
+        let playerOne = playerListViewModel.createPlayerWith(name: nameOne)
+        playerListViewModel.addPlayerToPlayerList(player: playerOne)
+        
+        let playerTwo = playerListViewModel.createPlayerWith(name: nameTwo)
+        playerListViewModel.addPlayerToPlayerList(player: playerTwo)
+        
+        // when
+        let totalPlayerList = playerListViewModel.getPlayerList()
+        
+        // then
+        XCTAssertEqual(totalPlayerList, [PlayerModel(name: "Kevin"), PlayerModel(name: "Lisa")])
+    }
+    
+    func testDeletePlayer() {
+        // given
+        let nameOne = "Kevin"
+        let nameTwo = "Lisa"
+        
+        let playerListModel = PlayerListModel(playerList: [])
+        let playerListViewModel = PlayerListViewModel(playerListModel: playerListModel
+        )
+        
+        let playerOne = playerListViewModel.createPlayerWith(name: nameOne)
+        playerListViewModel.addPlayerToPlayerList(player: playerOne)
+        
+        let playerTwo = playerListViewModel.createPlayerWith(name: nameTwo)
+        playerListViewModel.addPlayerToPlayerList(player: playerTwo)
+        
+        // when
+        playerListViewModel.deletePlayer(playerToDelete: playerOne)
+        
+        // then
+        XCTAssertEqual(playerListModel.playerList, [PlayerModel(name: "Lisa")])
+    }
+    
+    func testDeletePlayerWithSameName() {
+        // given
+        let nameOne = "Kevin"
+        let nameTwo = "Lisa"
+        let nameThree = "Kevin"
+        
+        let playerListModel = PlayerListModel(playerList: [])
+        let playerListViewModel = PlayerListViewModel(playerListModel: playerListModel
+        )
+        
+        let playerOne = playerListViewModel.createPlayerWith(name: nameOne)
+        playerListViewModel.addPlayerToPlayerList(player: playerOne)
+        
+        let playerTwo = playerListViewModel.createPlayerWith(name: nameTwo)
+        playerListViewModel.addPlayerToPlayerList(player: playerTwo)
+        
+        let playerThree = playerListViewModel.createPlayerWith(name: nameThree)
+        playerListViewModel.addPlayerToPlayerList(player: playerThree)
+        
+        // when
+        playerListViewModel.deletePlayer(playerToDelete: playerThree)
         
         // then
         XCTAssertEqual(playerListModel.playerList, [PlayerModel(name: "Kevin"), PlayerModel(name: "Lisa")])

--- a/SparkleSpinTests/ModelTests.swift
+++ b/SparkleSpinTests/ModelTests.swift
@@ -23,7 +23,8 @@ class ModelTests: XCTestCase {
         // given
         let name = "Kevin"
         let playerOneModel = PlayerModel(name: nil)
-        let playerOneViewModel = PlayerViewModel(playerModel: playerOneModel)
+        let playerListModel = PlayerListModel(playerList: [])
+        let playerOneViewModel = PlayerViewModel(playerModel: playerOneModel, playerListModel: playerListModel)
         
         // when
         playerOneViewModel.updateProperties(nameString: name)
@@ -49,14 +50,17 @@ class ModelTests: XCTestCase {
         // given
         let name = "Kevin"
         let playerOneModel = PlayerModel(name: nil)
-        let playerOneViewModel = PlayerViewModel(playerModel: playerOneModel)
+        let playerListModel = PlayerListModel(playerList: [])
+        let playerOneViewModel = PlayerViewModel(playerModel: playerOneModel, playerListModel: playerListModel
+        )
+        let expectedValue: [PlayerModel]? = [PlayerModel(name: name)]
 
         playerOneViewModel.updateProperties(nameString: name)
 
         // when
-        playerOneViewModel.addPlayerToPlayerList(player: Player)
+        playerOneViewModel.addPlayerToPlayerList(player: playerOneModel)
 
         // then
-        XCTAssertEqual(playerListModel.playerList, ["Kevin"])
+        XCTAssertEqual(playerListModel.playerList, expectedValue)
     }
 }

--- a/SparkleSpinTests/ModelTests.swift
+++ b/SparkleSpinTests/ModelTests.swift
@@ -44,4 +44,19 @@ class ModelTests: XCTestCase {
         // then
         XCTAssertEqual(choreOneModel.choreName, "Washing dishes")
     }
+    
+    func testAddPlayerToPlayerList() {
+        // given
+        let name = "Kevin"
+        let playerOneModel = PlayerModel(name: nil)
+        let playerOneViewModel = PlayerViewModel(playerModel: playerOneModel)
+
+        playerOneViewModel.updateProperties(nameString: name)
+
+        // when
+        playerOneViewModel.addPlayerToPlayerList(player: Player)
+
+        // then
+        XCTAssertEqual(playerListModel.playerList, ["Kevin"])
+    }
 }

--- a/SparkleSpinTests/ModelTests.swift
+++ b/SparkleSpinTests/ModelTests.swift
@@ -61,7 +61,7 @@ class ModelTests: XCTestCase {
         playerListViewModel.addPlayerToPlayerList(player: playerOne)
         
         // then
-        XCTAssertEqual(playerListModel.playerList?[0].name, "Kevin")
+        XCTAssertEqual(playerListModel.playerList?.first?.name, "Kevin")
     }
     
     func testAddAnotherPlayerToPlayerList() {

--- a/SparkleSpinTests/ModelTests.swift
+++ b/SparkleSpinTests/ModelTests.swift
@@ -62,4 +62,22 @@ class ModelTests: XCTestCase {
         // then
         XCTAssertEqual(playerListModel.playerList, [PlayerModel(name: "Kevin")])
     }
+    
+    func testAddTwoPlayersToPlayerList() {
+        // given
+        let nameOne = "Kevin"
+        let playerOneModel = PlayerModel(name: nil)
+        
+        let nameTwo = "Lisa"
+        let playerTwoModel = PlayerModel(name: nil)
+        
+        let playerListModel = PlayerListModel(playerList: [])
+        let playerOneViewModel = PlayerViewModel(playerModel: playerOneModel, playerListModel: playerListModel
+        )
+        
+        // when
+        
+        // then
+        
+    }
 }

--- a/SparkleSpinTests/ModelTests.swift
+++ b/SparkleSpinTests/ModelTests.swift
@@ -19,19 +19,21 @@ class ModelTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
     
-//    func testCreatePlayer() {
-//        // given
-//        let name = "Kevin"
-//        let playerOneModel = PlayerModel(name: nil)
-//        let playerListModel = PlayerListModel(playerList: [])
-//        let playerOneViewModel = PlayerViewModel(playerModels: [playerOneModel], playerListModel: playerListModel)
-//
-//        // when
-//        playerOneViewModel.updateProperties(nameString: name)
-//
-//        // then
-//        XCTAssertEqual(playerOneModel.name, "Kevin")
-//    }
+    func testCreateOnePlayer() {
+        // given
+        let name = "Kevin"
+        let nameList = [name]
+        
+        let playerListModel = PlayerListModel(playerList: [])
+        let playerListViewModel = PlayerListViewModel(playerListModel: playerListModel
+        )
+
+        // when
+        let _ = playerListViewModel.createPlayersWith(names: nameList)
+
+        // then
+        XCTAssertEqual(playerListModel.playerList,  [PlayerModel(name: "Kevin")])
+    }
 //
 //    func testCreateChore() {
 //        // given
@@ -63,7 +65,7 @@ class ModelTests: XCTestCase {
 //        XCTAssertEqual(playerListModel.playerList, [PlayerModel(name: "Kevin")])
 //    }
     
-    func testAddTwoPlayersToPlayerList() {
+    func testCreateTwoPlayers() {
         // given
         let nameOne = "Kevin"
         let nameTwo = "Lisa"

--- a/SparkleSpinTests/ModelTests.swift
+++ b/SparkleSpinTests/ModelTests.swift
@@ -53,7 +53,6 @@ class ModelTests: XCTestCase {
         let playerListModel = PlayerListModel(playerList: [])
         let playerOneViewModel = PlayerViewModel(playerModel: playerOneModel, playerListModel: playerListModel
         )
-        let expectedValue: [PlayerModel]? = [PlayerModel(name: name)]
 
         playerOneViewModel.updateProperties(nameString: name)
 
@@ -61,6 +60,6 @@ class ModelTests: XCTestCase {
         playerOneViewModel.addPlayerToPlayerList(player: playerOneModel)
 
         // then
-        XCTAssertEqual(playerListModel.playerList, expectedValue)
+        XCTAssertEqual(playerListModel.playerList, [PlayerModel(name: "Kevin")])
     }
 }

--- a/SparkleSpinTests/ModelTests.swift
+++ b/SparkleSpinTests/ModelTests.swift
@@ -150,6 +150,6 @@ class ModelTests: XCTestCase {
         
         // then
         guard let playerArray = playerListModel.playerList else { return }
-        XCTAssertEqual(Set(playerArray.map { $0.name }), Set(["Kevin", "Lisa"]))
+        XCTAssertEqual(playerArray.map { $0.name }, ["Kevin", "Lisa"])
     }
 }

--- a/SparkleSpinTests/ModelTests.swift
+++ b/SparkleSpinTests/ModelTests.swift
@@ -24,14 +24,13 @@ class ModelTests: XCTestCase {
         let name = "Kevin"
         
         let playerListModel = PlayerListModel(playerList: [])
-        let playerListViewModel = PlayerListViewModel(playerListModel: playerListModel
-        )
+        let playerListViewModel = PlayerListViewModel(playerListModel: playerListModel)
 
         // when
         let playerOne = playerListViewModel.createPlayerWith(name: name)
 
         // then
-        XCTAssertEqual(playerOne,  PlayerModel(name: "Kevin"))
+        XCTAssertEqual(playerOne.name, "Kevin")
     }
     
     func testCreateTwoPlayers() {
@@ -40,15 +39,14 @@ class ModelTests: XCTestCase {
         let nameTwo = "Lisa"
         
         let playerListModel = PlayerListModel(playerList: [])
-        let playerListViewModel = PlayerListViewModel(playerListModel: playerListModel
-        )
+        let playerListViewModel = PlayerListViewModel(playerListModel: playerListModel)
         
         // when
         let playerOne = playerListViewModel.createPlayerWith(name: nameOne)
         let playerTwo = playerListViewModel.createPlayerWith(name: nameTwo)
         
         // then
-        XCTAssertEqual([playerOne, playerTwo], [PlayerModel(name: "Kevin"), PlayerModel(name: "Lisa")])
+        XCTAssertEqual([playerOne.name, playerTwo.name], ["Kevin", "Lisa"])
     }
     
     func testAddOnePlayerToPlayerList() {
@@ -63,7 +61,7 @@ class ModelTests: XCTestCase {
         playerListViewModel.addPlayerToPlayerList(player: playerOne)
         
         // then
-        XCTAssertEqual(playerListModel.playerList, [PlayerModel(name: "Kevin")])
+        XCTAssertEqual(playerListModel.playerList?[0].name, "Kevin")
     }
     
     func testAddAnotherPlayerToPlayerList() {
@@ -72,8 +70,7 @@ class ModelTests: XCTestCase {
         let nameTwo = "Lisa"
         
         let playerListModel = PlayerListModel(playerList: [])
-        let playerListViewModel = PlayerListViewModel(playerListModel: playerListModel
-        )
+        let playerListViewModel = PlayerListViewModel(playerListModel: playerListModel)
         
         let playerOne = playerListViewModel.createPlayerWith(name: nameOne)
         playerListViewModel.addPlayerToPlayerList(player: playerOne)
@@ -83,7 +80,8 @@ class ModelTests: XCTestCase {
         playerListViewModel.addPlayerToPlayerList(player: playerTwo)
         
         // then
-        XCTAssertEqual(playerListModel.playerList, [PlayerModel(name: "Kevin"), PlayerModel(name: "Lisa")])
+        guard let playerList = playerListModel.playerList else { return }
+        XCTAssertEqual(playerList.map { $0.name }, ["Kevin", "Lisa"])
         
     }
     
@@ -93,8 +91,7 @@ class ModelTests: XCTestCase {
         let nameTwo = "Lisa"
         
         let playerListModel = PlayerListModel(playerList: [])
-        let playerListViewModel = PlayerListViewModel(playerListModel: playerListModel
-        )
+        let playerListViewModel = PlayerListViewModel(playerListModel: playerListModel)
         
         let playerOne = playerListViewModel.createPlayerWith(name: nameOne)
         playerListViewModel.addPlayerToPlayerList(player: playerOne)
@@ -106,7 +103,7 @@ class ModelTests: XCTestCase {
         let totalPlayerList = playerListViewModel.getPlayerList()
         
         // then
-        XCTAssertEqual(totalPlayerList, [PlayerModel(name: "Kevin"), PlayerModel(name: "Lisa")])
+        XCTAssertEqual(totalPlayerList.map { $0.name }, ["Kevin", "Lisa"])
     }
     
     func testDeletePlayer() {
@@ -115,8 +112,7 @@ class ModelTests: XCTestCase {
         let nameTwo = "Lisa"
         
         let playerListModel = PlayerListModel(playerList: [])
-        let playerListViewModel = PlayerListViewModel(playerListModel: playerListModel
-        )
+        let playerListViewModel = PlayerListViewModel(playerListModel: playerListModel)
         
         let playerOne = playerListViewModel.createPlayerWith(name: nameOne)
         playerListViewModel.addPlayerToPlayerList(player: playerOne)
@@ -128,7 +124,7 @@ class ModelTests: XCTestCase {
         playerListViewModel.deletePlayer(playerToDelete: playerOne)
         
         // then
-        XCTAssertEqual(playerListModel.playerList, [PlayerModel(name: "Lisa")])
+        XCTAssertEqual(playerListModel.playerList?[0].name, "Lisa")
     }
     
     func testDeletePlayerWithSameName() {
@@ -138,8 +134,7 @@ class ModelTests: XCTestCase {
         let nameThree = "Kevin"
         
         let playerListModel = PlayerListModel(playerList: [])
-        let playerListViewModel = PlayerListViewModel(playerListModel: playerListModel
-        )
+        let playerListViewModel = PlayerListViewModel(playerListModel: playerListModel)
         
         let playerOne = playerListViewModel.createPlayerWith(name: nameOne)
         playerListViewModel.addPlayerToPlayerList(player: playerOne)
@@ -154,7 +149,7 @@ class ModelTests: XCTestCase {
         playerListViewModel.deletePlayer(playerToDelete: playerThree)
         
         // then
-        XCTAssertEqual(playerListModel.playerList, [PlayerModel(name: "Kevin"), PlayerModel(name: "Lisa")])
-        
+        guard let playerArray = playerListModel.playerList else { return }
+        XCTAssertEqual(Set(playerArray.map { $0.name }), Set(["Kevin", "Lisa"]))
     }
 }

--- a/SparkleSpinTests/ModelTests.swift
+++ b/SparkleSpinTests/ModelTests.swift
@@ -18,66 +18,66 @@ class ModelTests: XCTestCase {
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
-
-    func testCreatePlayer() {
-        // given
-        let name = "Kevin"
-        let playerOneModel = PlayerModel(name: nil)
-        let playerListModel = PlayerListModel(playerList: [])
-        let playerOneViewModel = PlayerViewModel(playerModel: playerOneModel, playerListModel: playerListModel)
-        
-        // when
-        playerOneViewModel.updateProperties(nameString: name)
-        
-        // then
-        XCTAssertEqual(playerOneModel.name, "Kevin")
-    }
     
-    func testCreateChore() {
-        // given
-        let choreName = "Washing dishes"
-        let choreOneModel = ChoreModel(choreName: nil)
-        let choreOneViewModel = ChoreViewModel(choreModel: choreOneModel)
-        
-        // when
-        choreOneViewModel.updateProperties(choreNameString: choreName)
-        
-        // then
-        XCTAssertEqual(choreOneModel.choreName, "Washing dishes")
-    }
-    
-    func testAddPlayerToPlayerList() {
-        // given
-        let name = "Kevin"
-        let playerOneModel = PlayerModel(name: nil)
-        let playerListModel = PlayerListModel(playerList: [])
-        let playerOneViewModel = PlayerViewModel(playerModel: playerOneModel, playerListModel: playerListModel
-        )
-
-        playerOneViewModel.updateProperties(nameString: name)
-
-        // when
-        playerOneViewModel.addPlayerToPlayerList(player: playerOneModel)
-
-        // then
-        XCTAssertEqual(playerListModel.playerList, [PlayerModel(name: "Kevin")])
-    }
+//    func testCreatePlayer() {
+//        // given
+//        let name = "Kevin"
+//        let playerOneModel = PlayerModel(name: nil)
+//        let playerListModel = PlayerListModel(playerList: [])
+//        let playerOneViewModel = PlayerViewModel(playerModels: [playerOneModel], playerListModel: playerListModel)
+//
+//        // when
+//        playerOneViewModel.updateProperties(nameString: name)
+//
+//        // then
+//        XCTAssertEqual(playerOneModel.name, "Kevin")
+//    }
+//
+//    func testCreateChore() {
+//        // given
+//        let choreName = "Washing dishes"
+//        let choreOneModel = ChoreModel(choreName: nil)
+//        let choreOneViewModel = ChoreViewModel(choreModel: choreOneModel)
+//
+//        // when
+//        choreOneViewModel.updateProperties(choreNameString: choreName)
+//
+//        // then
+//        XCTAssertEqual(choreOneModel.choreName, "Washing dishes")
+//    }
+//
+//    func testAddPlayerToPlayerList() {
+//        // given
+//        let name = "Kevin"
+//        let playerOneModel = PlayerModel(name: nil)
+//        let playerListModel = PlayerListModel(playerList: [])
+//        let playerOneViewModel = PlayerViewModel(playerModels: [playerOneModel], playerListModel: playerListModel
+//        )
+//
+//        playerOneViewModel.updateProperties(nameString: name)
+//
+//        // when
+//        playerOneViewModel.addPlayerToPlayerList(player: playerOneModel)
+//
+//        // then
+//        XCTAssertEqual(playerListModel.playerList, [PlayerModel(name: "Kevin")])
+//    }
     
     func testAddTwoPlayersToPlayerList() {
         // given
         let nameOne = "Kevin"
-        let playerOneModel = PlayerModel(name: nil)
-        
         let nameTwo = "Lisa"
-        let playerTwoModel = PlayerModel(name: nil)
+        let nameList = [nameOne, nameTwo]
         
         let playerListModel = PlayerListModel(playerList: [])
-        let playerOneViewModel = PlayerViewModel(playerModel: playerOneModel, playerListModel: playerListModel
+        let playerViewModel = PlayerViewModel(/*playerModels: [playerOneModel, playerTwoModel],*/ playerListModel: playerListModel
         )
         
         // when
+        playerViewModel.createPlayersWith(names: nameList)
         
         // then
+        XCTAssertEqual(playerListModel.playerList, [PlayerModel(name: "Kevin"), PlayerModel(name: "Lisa")])
         
     }
 }

--- a/SparkleSpinTests/ModelTests.swift
+++ b/SparkleSpinTests/ModelTests.swift
@@ -70,11 +70,11 @@ class ModelTests: XCTestCase {
         let nameList = [nameOne, nameTwo]
         
         let playerListModel = PlayerListModel(playerList: [])
-        let playerViewModel = PlayerViewModel(/*playerModels: [playerOneModel, playerTwoModel],*/ playerListModel: playerListModel
+        let playerListViewModel = PlayerListViewModel(playerListModel: playerListModel
         )
         
         // when
-        playerViewModel.createPlayersWith(names: nameList)
+        playerListViewModel.createPlayersWith(names: nameList)
         
         // then
         XCTAssertEqual(playerListModel.playerList, [PlayerModel(name: "Kevin"), PlayerModel(name: "Lisa")])

--- a/SparkleSpinTests/ModelTests.swift
+++ b/SparkleSpinTests/ModelTests.swift
@@ -74,7 +74,7 @@ class ModelTests: XCTestCase {
         )
         
         // when
-        playerListViewModel.createPlayersWith(names: nameList)
+        let _ = playerListViewModel.createPlayersWith(names: nameList)
         
         // then
         XCTAssertEqual(playerListModel.playerList, [PlayerModel(name: "Kevin"), PlayerModel(name: "Lisa")])


### PR DESCRIPTION
## What you did :question:
This PR adds unit tests in 'ModelTests' for the following operations: 
- Creating a player
- Creating multiple players
- Adding one player to a player list
- Adding multiple players to a player list
- Getting the player list
- Deleting one player
- Deleting a player that has the same name of a previously saved player

## How to test it :microscope:
1. Check out this branch
2. Run the app
3. Push `cmd + U` to run all unit tests
4. Note that all unit tests should pass

## Any background context you want to provide? :question:
- I've removed the original tests I wrote for chore additions for now. Since I restructured how I handled CRUD operations in the `PlayerListViewModel` (formerly known as `PlayerViewModel`) while writing the tests, a similar restructuring will probably be needed for any chore models and view models at a later date.

- I will add tests and functionality for editing a player at a later date.

- While writing the tests and view model methods, I ran into a problem: I wanted a user to be able to delete a player even if that player had the same name as a player from another entry. I explored two solutions: Sets and NSUUID. I learned about the advantages of sets, but I ultimately decided that adding a 'uuid' property to the player model that holds a generated uuid string worked out for my needs. A consequence of this is that for the tests, I could not test for object equality (since a Player instance was now unique by uuid), so I tested for matching name values instead.

## Screenshots (if applicable) :camera:
N/A