### PR TITLE
Player source check

### DIFF
--- a/SparkleSpin/Controllers/PlayerViewController.swift
+++ b/SparkleSpin/Controllers/PlayerViewController.swift
@@ -26,7 +26,7 @@ class PlayerViewController: UIViewController {
         addDoneBarButtonItem()
         playerViewModelObservationToken = observe(\.playerViewModel.playerList, options: [.new], changeHandler: { [unowned self](vc, change) in
             if change.newValue!.isEmpty {
-                vc.doneBarButton?.isEnabled = false
+                self.doneBarButton?.isEnabled = false
             }
         })
     }

--- a/SparkleSpin/Controllers/PlayerViewController.swift
+++ b/SparkleSpin/Controllers/PlayerViewController.swift
@@ -14,8 +14,9 @@ class PlayerViewController: UIViewController {
     @IBOutlet weak var playerEntryTextField: CustomTextField!
     @IBOutlet weak var addPlayerButton: LightButton! 
     
-    let playerViewModel = PlayerViewModel()
+    @objc let playerViewModel = PlayerViewModel()
     var doneBarButton: UIBarButtonItem?
+    var playerViewModelObservationToken: NSKeyValueObservation?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -23,6 +24,18 @@ class PlayerViewController: UIViewController {
         registerNib()
         setupTableView()
         addDoneBarButtonItem()
+        playerViewModelObservationToken = observe(\.playerViewModel.playerList, options: [.new], changeHandler: { [unowned self](vc, change) in
+            if change.newValue!.isEmpty {
+                vc.doneBarButton?.isEnabled = false
+            }
+        })
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        
+        // Invalidate observation tokens to stop observing
+        playerViewModelObservationToken?.invalidate()
     }
     
     private func setNavigationBarTitle() {

--- a/SparkleSpin/Controllers/PlayerViewController.swift
+++ b/SparkleSpin/Controllers/PlayerViewController.swift
@@ -24,6 +24,10 @@ class PlayerViewController: UIViewController {
         registerNib()
         setupTableView()
         addDoneBarButtonItem()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         setObservationToken()
     }
     

--- a/SparkleSpin/Controllers/PlayerViewController.swift
+++ b/SparkleSpin/Controllers/PlayerViewController.swift
@@ -34,6 +34,22 @@ class PlayerViewController: UIViewController {
         playerViewModelObservationToken?.invalidate()
     }
     
+    @IBAction func userTappedAddButton(_ sender: LightButton) {
+        addPlayerButton.animateButton()
+        guard let playerEntryText = playerEntryTextField.text else { return }
+        if !playerEntryText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            addPlayerToList()
+            updateDoneBarButton()
+            insertNewPlayerRowInTable()
+        } else {
+            alertForEmptyEntry()
+        }
+    }
+}
+
+// MARK: Private Methods
+extension PlayerViewController {
+    
     private func setNavigationBarTitle() {
         navigationItem.title = "Add Players!"
     }
@@ -90,18 +106,6 @@ class PlayerViewController: UIViewController {
         let emptyEntryAlert = UIAlertController(title: "Oops!", message: "Entry cannot be blank!", preferredStyle: .alert)
         emptyEntryAlert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
         present(emptyEntryAlert, animated: true)
-    }
-    
-    @IBAction func userTappedAddButton(_ sender: LightButton) {
-        addPlayerButton.animateButton()
-        guard let playerEntryText = playerEntryTextField.text else { return }
-        if !playerEntryText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            addPlayerToList()
-            updateDoneBarButton()
-            insertNewPlayerRowInTable()
-        } else {
-            alertForEmptyEntry()
-        }
     }
 }
 

--- a/SparkleSpin/Controllers/PlayerViewController.swift
+++ b/SparkleSpin/Controllers/PlayerViewController.swift
@@ -24,11 +24,7 @@ class PlayerViewController: UIViewController {
         registerNib()
         setupTableView()
         addDoneBarButtonItem()
-        playerViewModelObservationToken = observe(\.playerViewModel.playerList, options: [.new], changeHandler: { [unowned self](vc, change) in
-            if change.newValue!.isEmpty {
-                self.doneBarButton?.isEnabled = false
-            }
-        })
+        setObservationToken()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -40,6 +36,14 @@ class PlayerViewController: UIViewController {
     
     private func setNavigationBarTitle() {
         navigationItem.title = "Add Players!"
+    }
+    
+    private func setObservationToken() {
+        playerViewModelObservationToken = observe(\.playerViewModel.playerList, options: [.new], changeHandler: { [unowned self](vc, change) in
+            if change.newValue!.isEmpty {
+                self.doneBarButton?.isEnabled = false
+            }
+        })
     }
     
     private func addDoneBarButtonItem() {

--- a/SparkleSpin/Models/PlayerModel.swift
+++ b/SparkleSpin/Models/PlayerModel.swift
@@ -8,18 +8,12 @@
 
 import Foundation
 
-struct PlayerModel {
+class PlayerModel: NSObject {
     var name: String?
     var isSelected = false
     
     init(name: String?) {
         self.name = name
-    }
-}
-
-extension PlayerModel: Equatable {
-    static func == (lhs: PlayerModel, rhs: PlayerModel) -> Bool {
-        return lhs.name == rhs.name
     }
 }
 

--- a/SparkleSpin/PlayerViewModel.swift
+++ b/SparkleSpin/PlayerViewModel.swift
@@ -11,7 +11,7 @@ import UIKit
 
 class PlayerViewModel: NSObject {
     
-    var playerList = [PlayerModel]()
+    @objc dynamic var playerList = [PlayerModel]()
     
     func savePlayerEntry(name: String) {
         let player = PlayerModel(name: name)


### PR DESCRIPTION
## What you did :question:
This PR fixes a bug:

**Expected (current) behavior:** When any number of players are added, then deleted so that there are no valid players on the 'Add Players' screen, the 'Done' button becomes disabled and greyed out.

**Actual (fixed) behavior**: When any number of players are added, then deleted so that there were no valid players added, the 'Done' button would not become disabled (greyed out) as expected.

## How to test it :microscope:
1. Checkout out this branch
2. Run the app
3. Tap the 'Start' button
4. Note that the 'Add Players' screen appears, with the cursor in the top text field, and the 'Done' button greyed out
5. Type anything in the text field to represent a player name, and add the player by tapping the + button
6. Note that a cell with the player name is added to the tableview below, and the 'Done' button is no longer greyed out
7. Swipe the cell to delete the user
8. Note that the 'Done' button greyed out

## Any background context you want to provide? :question:
N/A


## Screenshots (if applicable) :camera:
![sparklespin-pr-done-bug-fix](https://user-images.githubusercontent.com/8409475/56921708-7f013380-6a94-11e9-8a16-c29548c1cfbf.gif)
