### PR TITLE
Player name entry trim and character limit

### DIFF
--- a/SparkleSpin/PlayerViewModel.swift
+++ b/SparkleSpin/PlayerViewModel.swift
@@ -14,7 +14,8 @@ class PlayerViewModel: NSObject {
     var playerList = [PlayerModel]()
     
     func savePlayerEntry(name: String) {
-        let player = PlayerModel(name: name)
+        let trimmedString = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let player = PlayerModel(name: trimmedString)
         playerList.append(player)
     }
 }

--- a/SparkleSpin/Views/CustomTextField.swift
+++ b/SparkleSpin/Views/CustomTextField.swift
@@ -14,6 +14,7 @@ class CustomTextField: UITextField {
         super.init(coder: aDecoder)
         styleTextField()
         becomeFirstResponder()
+        delegate = self
     }
     
     private func styleTextField() {
@@ -23,4 +24,16 @@ class CustomTextField: UITextField {
         font = Font.wheelBodyFont
         tintColor = ThemeColor.Light.accentColorOne
     }
+}
+
+extension CustomTextField: UITextFieldDelegate {
+    
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        let characterLimit = 21
+        guard let text = text else { return false }
+        let currentTextString = text as NSString
+        let newTextString = currentTextString.replacingCharacters(in: range, with: string) as NSString
+        return newTextString.length <= characterLimit
+    }
+    
 }

--- a/SparkleSpinTests/PlayerViewModelTests.swift
+++ b/SparkleSpinTests/PlayerViewModelTests.swift
@@ -37,4 +37,16 @@ class ModelTests: XCTestCase {
         let playerList = playerViewModel.playerList
         XCTAssertEqual(playerList.map { $0.name }, ["Kevin", "Lisa"])
     }
+    
+    func testAddPlayerWithLeadingAndTrailingWhiteSpace() {
+        // given
+        let playerViewModel = PlayerViewModel()
+        let name = "   Kevin Walsh    "
+        
+        // when
+        playerViewModel.savePlayerEntry(name: name)
+        
+        // then
+        XCTAssertEqual(playerViewModel.playerList.first?.name, "Kevin Walsh")
+    }
 }


### PR DESCRIPTION
## What you did :question:
This PR adds a character limit of 21 to the `CustomTextField`, and trims the leading and trailing whitespace characters from the player name entry in the `PlayerViewModel` before that player is appended to the `playerList`.

## How to test it :microscope:
1. Checkout out this branch
2. Run the app
3. Tap the 'Start' button
4. Note that the 'Add Players' screen appears, with the cursor in the top text field, and the 'Done' button greyed out
5. Attempt to enter a player name with more than 21 characters in the player name textfield. You should not be able to.
6. Attempt to enter a player name with leading and trailing whitespace, for example `     Britney Smith     `, and tap the `+` button to add the player. Note that the player is added as `Britney Smith`, with leading and trailing whitespace trimmed.

## Any background context you want to provide? :question:
Bugfix for the `Done` button is fixed in PR https://github.com/BritneyS/SparkleSpin/pull/11


## Screenshots (if applicable) :camera:
![sparklespin-pr-char-limit-trim](https://user-images.githubusercontent.com/8409475/56967314-f5eb0a80-6b2e-11e9-944c-4f1adee54a96.gif)
