### PR TITLE
Chore model

### DIFF
--- a/SparkleSpin.xcodeproj/project.pbxproj
+++ b/SparkleSpin.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		0601DE2B223EAF2400CFBDE3 /* EntryCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0601DE29223EAF2400CFBDE3 /* EntryCell.xib */; };
 		0601DE2D22402C0F00CFBDE3 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0601DE2C22402C0F00CFBDE3 /* Constants.swift */; };
 		0601DE2F2242913500CFBDE3 /* PlayerListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0601DE2E2242913500CFBDE3 /* PlayerListModel.swift */; };
+		060B999A2279D2FE00D3F23C /* ChoreViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 060B99992279D2FE00D3F23C /* ChoreViewModelTests.swift */; };
 		060C4D11221F425600B0BB07 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 060C4D10221F425600B0BB07 /* Images.xcassets */; };
 		060C4D13222047AC00B0BB07 /* JUICE_Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 060C4D12222047AC00B0BB07 /* JUICE_Regular.ttf */; };
 		060C4D15222047BA00B0BB07 /* Library 3 am.otf in Resources */ = {isa = PBXBuildFile; fileRef = 060C4D14222047BA00B0BB07 /* Library 3 am.otf */; };
@@ -57,6 +58,7 @@
 		0601DE29223EAF2400CFBDE3 /* EntryCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EntryCell.xib; sourceTree = "<group>"; };
 		0601DE2C22402C0F00CFBDE3 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		0601DE2E2242913500CFBDE3 /* PlayerListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerListModel.swift; sourceTree = "<group>"; };
+		060B99992279D2FE00D3F23C /* ChoreViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChoreViewModelTests.swift; sourceTree = "<group>"; };
 		060C4D10221F425600B0BB07 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		060C4D12222047AC00B0BB07 /* JUICE_Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = JUICE_Regular.ttf; sourceTree = "<group>"; };
 		060C4D14222047BA00B0BB07 /* Library 3 am.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Library 3 am.otf"; sourceTree = "<group>"; };
@@ -200,6 +202,7 @@
 			isa = PBXGroup;
 			children = (
 				064A01AF221B3BEF001AE3AF /* ModelTests.swift */,
+				060B99992279D2FE00D3F23C /* ChoreViewModelTests.swift */,
 				064A01B1221B3BEF001AE3AF /* Info.plist */,
 			);
 			path = SparkleSpinTests;
@@ -358,6 +361,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				060B999A2279D2FE00D3F23C /* ChoreViewModelTests.swift in Sources */,
 				064A01B0221B3BEF001AE3AF /* ModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SparkleSpin/ChoreViewModel.swift
+++ b/SparkleSpin/ChoreViewModel.swift
@@ -13,7 +13,7 @@ class ChoreViewModel: NSObject {
     var choreList = [ChoreModel]()
     
     func saveChoreEntry(name: String) {
-        let trimmedString = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedString = name.trimmingCharacters(in: .whitespaces)
         let chore = ChoreModel(choreName: trimmedString)
         choreList.append(chore)
     }

--- a/SparkleSpin/ChoreViewModel.swift
+++ b/SparkleSpin/ChoreViewModel.swift
@@ -6,16 +6,15 @@
 //  Copyright © 2019 Britney Smith. All rights reserved.
 //
 
-class ChoreViewModel {
+import Foundation
+
+class ChoreViewModel: NSObject {
     
-    private let choreModel: ChoreModel
-    var choreNameString: String? = nil
+    var choreList = [ChoreModel]()
     
-    init(choreModel: ChoreModel) {
-        self.choreModel = choreModel
-    }
-    
-    func updateProperties(choreNameString: String) {
-        choreModel.choreName = choreNameString
+    func saveChoreEntry(name: String) {
+        let trimmedString = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let chore = ChoreModel(choreName: trimmedString)
+        choreList.append(chore)
     }
 }

--- a/SparkleSpin/Models/ChoreModel.swift
+++ b/SparkleSpin/Models/ChoreModel.swift
@@ -6,8 +6,11 @@
 //  Copyright © 2019 Britney Smith. All rights reserved.
 //
 
-class ChoreModel {
+import Foundation
+
+class ChoreModel: NSObject {
     var choreName: String?
+    var isSelected = false
     
     init(choreName: String?) {
         self.choreName = choreName

--- a/SparkleSpinTests/ChoreViewModelTests.swift
+++ b/SparkleSpinTests/ChoreViewModelTests.swift
@@ -50,22 +50,4 @@ class ChoreViewModelTests: XCTestCase {
         XCTAssertEqual(choreViewModel.choreList.first?.choreName, "Wash dishes")
         
     }
-    
-    func testAddChoreWithNewLineBeforeAndAfter() {
-        // given
-        let choreViewModel = ChoreViewModel()
-        let name = """
-
-        Wash dishes
-
-        """
-        
-        // when
-        choreViewModel.saveChoreEntry(name: name)
-        
-        // then
-        XCTAssertEqual(choreViewModel.choreList.first?.choreName, "Wash dishes")
-    }
-    
-
 }

--- a/SparkleSpinTests/ChoreViewModelTests.swift
+++ b/SparkleSpinTests/ChoreViewModelTests.swift
@@ -37,5 +37,18 @@ class ChoreViewModelTests: XCTestCase {
         let choreList = choreViewModel.choreList
         XCTAssertEqual(choreList.map { $0.choreName }, ["Wash dishes", "Do laundry"])
     }
+    
+    func testAddChoreWithLeadingAndTrailingWhiteSpace() {
+        // given
+        let choreViewModel = ChoreViewModel()
+        let name = "   Wash dishes    "
+        
+        // when
+        choreViewModel.saveChoreEntry(name: name)
+        
+        // then
+        XCTAssertEqual(choreViewModel.choreList.first?.choreName, "Wash dishes")
+        
+    }
 
 }

--- a/SparkleSpinTests/ChoreViewModelTests.swift
+++ b/SparkleSpinTests/ChoreViewModelTests.swift
@@ -50,5 +50,22 @@ class ChoreViewModelTests: XCTestCase {
         XCTAssertEqual(choreViewModel.choreList.first?.choreName, "Wash dishes")
         
     }
+    
+    func testAddChoreWithNewLineBeforeAndAfter() {
+        // given
+        let choreViewModel = ChoreViewModel()
+        let name = """
+
+        Wash dishes
+
+        """
+        
+        // when
+        choreViewModel.saveChoreEntry(name: name)
+        
+        // then
+        XCTAssertEqual(choreViewModel.choreList.first?.choreName, "Wash dishes")
+    }
+    
 
 }

--- a/SparkleSpinTests/ChoreViewModelTests.swift
+++ b/SparkleSpinTests/ChoreViewModelTests.swift
@@ -1,0 +1,41 @@
+//
+//  ChoreViewModelTests.swift
+//  SparkleSpinTests
+//
+//  Created by Britney Smith on 5/1/19.
+//  Copyright © 2019 Britney Smith. All rights reserved.
+//
+
+import XCTest
+@testable import SparkleSpin
+
+class ChoreViewModelTests: XCTestCase {
+
+    func testAddOneChoreToChoreList() {
+        // given
+        let choreViewModel = ChoreViewModel()
+        let name = "Wash dishes"
+        
+        // when
+        choreViewModel.saveChoreEntry(name: name)
+        
+        // then
+        XCTAssertEqual(choreViewModel.choreList.first?.choreName, "Wash dishes")
+    }
+    
+    func testAddAnotherChoreToChoreList() {
+        // given
+        let choreViewModel = ChoreViewModel()
+        let nameOne = "Wash dishes"
+        let nameTwo = "Do laundry"
+        choreViewModel.saveChoreEntry(name: nameOne)
+        
+        // when
+        choreViewModel.saveChoreEntry(name: nameTwo)
+        
+        // then
+        let choreList = choreViewModel.choreList
+        XCTAssertEqual(choreList.map { $0.choreName }, ["Wash dishes", "Do laundry"])
+    }
+
+}


### PR DESCRIPTION
## What you did :question:
This PR updates the `ChoreModel` and `ChoreViewModel` to be more in line with the `PlayerModel` and `PlayerViewModel` in the `player-screen` branch [here](https://github.com/BritneyS/SparkleSpin/tree/player-screen). `ChoreViewModelTests` were also added.

## How to test it :microscope:
1. Check out this branch
2. Navigate to `SparkleSpinTests > ChoreViewModelTests.swift`
3. Click the `play` button next to `class ChoreViewModelTests: XCTestCase { ` (line 12) to run all test cases in the `ChoreViewModelTests` test suite (see screenshots).
4. Note that all unit tests in that suite should pass.


## Any background context you want to provide? :question:
I'm planning to add the equivalent to the test `testAddChoreWithLeadingAndTrailingWhiteSpace()` to PR https://github.com/BritneyS/SparkleSpin/pull/12.


## Screenshots (if applicable) :camera:
![Screen Shot 2019-05-01 at 11 01 28 AM](https://user-images.githubusercontent.com/8409475/57023647-94936c00-6c00-11e9-8b0f-9d4755049a32.png)
![Screen Shot 2019-05-01 at 11 02 04 AM](https://user-images.githubusercontent.com/8409475/57023664-9e1cd400-6c00-11e9-8c11-3fb01d539962.png)

